### PR TITLE
Release/0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,14 +44,14 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 
 ## ⚙️ Configuration
 
-### Main options
 
-| Name      | Type                | Default    | Description                                           |
-|-----------|---------------------|------------|-------------------------------------------------------|
-| `routes`  | [Routes](#routes)   | `Required` | Defines the array of routes to be shown in the navbar |
-| `desktop` | [Desktop](#desktop) | -          | Options specific to desktop mode                      |
-| `mobile`  | [Mobile](#mobile)   | -          | Options specific to mobile mode                       |
-| `styles`  | [Styles](#styles)   | -          | Custom CSS styles for the card                        |
+| Name      | Type                   | Default    | Description                                           |
+|-----------|------------------------|------------|-------------------------------------------------------|
+| `routes`  | [Routes](#routes)      | `Required` | Defines the array of routes to be shown in the navbar |
+| `template`| [Template](#templates) | -          | Template name                                         |
+| `desktop` | [Desktop](#desktop)    | -          | Options specific to desktop mode                      |
+| `mobile`  | [Mobile](#mobile)      | -          | Options specific to mobile mode                       |
+| `styles`  | [Styles](#styles)      | -          | Custom CSS styles for the card                        |
 
 
 ### Routes
@@ -80,6 +80,59 @@ Configuration to display a small badge on any of the navbar items.
 |------------	|-------------	|---------	|-----------------------------------------------------------------	|
 | `template` 	| JS template 	| -       	| Boolean template indicating whether to display the badge or not 	|
 | `color`    	| string      	| red     	| Background color of the badge                                   	|
+
+### Templates
+
+Templates allow you to predefine a custom configuration for `navbar-card` and reuse it across multiple dashboards. This approach saves time and simplifies maintenance — any change to the template will automatically apply to all cards using it. 
+
+#### Defining Templates
+
+To define custom templates, add them under `navbar-templates` in your main Lovelace YAML configuration like this:
+
+```yaml
+navbar-templates:
+   your_template_name:
+      # Your navbar config
+      routes:
+         - label: Home
+           icon: mdi:home
+           url: /lovelace/home
+         ...
+# Your normal lovelace configuration
+views:
+...
+```
+
+#### Referencing Templates
+You can reference a template from your `navbar-card` using the template property:
+
+```yaml
+type: custom:navbar-card
+template: your_template_name
+```
+
+#### Overriding props
+
+Card properties defined directly in the card will take priority over those inherited from the template.
+
+For example, if you want to use a template called `your_template_name` but have one specific dashboard with a different primary color, your configurations might look like this:
+
+- Default Navbar for Most Views:
+```yaml
+type: custom:navbar-card
+template: your_template_name
+```
+
+- Customized Navbar for a Specific View:
+
+```yaml
+type: custom:navbar-card
+template: your_template_name
+styles: |
+  .navbar {
+    --navbar-primary-color: red;
+  }
+```
 
 
 ### Desktop

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,0 +1,19 @@
+import { NavbarCardConfig } from './types';
+
+export const getNavbarTemplates = (): Record<
+  string,
+  NavbarCardConfig
+> | null => {
+  const lovelacePanel = document
+    ?.querySelector('home-assistant')
+    ?.shadowRoot?.querySelector('home-assistant-main')
+    ?.shadowRoot?.querySelector(
+      'ha-drawer partial-panel-resolver ha-panel-lovelace',
+    );
+  if (lovelacePanel) {
+    // TODO add proper typing
+    // @ts-ignore
+    return lovelacePanel.lovelace.config['navbar-card'];
+  }
+  return null;
+};

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -92,30 +92,6 @@ export class NavbarCard extends LitElement {
         ?.shadowRoot?.querySelector(
           'ha-dialog > div.content > div.element-preview',
         ) != null;
-
-    // Check for template configuration
-    if (this._config?.template) {
-      // Get templates from the DOM
-      const templates = getNavbarTemplates();
-
-      // If no templates are found, but the card is configured to use a template, warn and use the default configuration.
-      if (!templates) {
-        console.warn(
-          '[navbar-card] No templates configured in this dashboard. Please refer to "templates" documentation for more information.' +
-            '\n\n' +
-            'https://github.com/joseluis9595/lovelace-navbar-card?tab=readme-ov-file#templates\n',
-        );
-      } else {
-        // Merge template configuration with the card configuration, giving priority to the card
-        const templateConfig = templates[this._config.template];
-        if (templateConfig) {
-          this._config = {
-            ...templateConfig,
-            ...this._config,
-          };
-        }
-      }
-    }
   }
 
   disconnectedCallback() {
@@ -128,6 +104,31 @@ export class NavbarCard extends LitElement {
    * Set config
    */
   setConfig(config) {
+    // Check for template configuration
+    if (config?.template) {
+      // Get templates from the DOM
+      const templates = getNavbarTemplates();
+
+      // If no templates are found, but the card is configured to use a template, warn and use the default configuration.
+      if (!templates) {
+        console.warn(
+          '[navbar-card] No templates configured in this dashboard. Please refer to "templates" documentation for more information.' +
+            '\n\n' +
+            'https://github.com/joseluis9595/lovelace-navbar-card?tab=readme-ov-file#templates\n',
+        );
+      } else {
+        // Merge template configuration with the card configuration, giving priority to the card
+        const templateConfig = templates[config.template];
+        if (templateConfig) {
+          config = {
+            ...templateConfig,
+            ...config,
+          };
+        }
+      }
+    }
+
+    // Check for valid configuration
     if (!config.routes) {
       throw new Error('"routes" param is required for navbar card');
     }
@@ -141,6 +142,8 @@ export class NavbarCard extends LitElement {
         );
       }
     });
+
+    // Store configuration
     this._config = config;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,34 @@
+import { ActionConfig } from 'custom-card-helpers';
+
 export enum DesktopPosition {
   top = 'top',
   left = 'left',
   bottom = 'bottom',
   right = 'right',
 }
+
+export type RouteItem = {
+  url: string;
+  icon: string;
+  icon_selected?: string;
+  label?: string;
+  badge?: {
+    template?: string;
+    color?: string;
+  };
+  tap_action?: ActionConfig;
+};
+
+export type NavbarCardConfig = {
+  routes: RouteItem[];
+  template?: string;
+  desktop?: {
+    show_labels?: boolean;
+    min_width?: number;
+    position?: DesktopPosition;
+  };
+  mobile?: {
+    show_labels?: boolean;
+  };
+  styles?: string;
+};


### PR DESCRIPTION
## Templates support

Using navbar-card just got a lot easier! You can now create **templates**, and reference them from each navbar-card you add to your dashboard, making it easier to apply modifications to all instances.

#### How It Works:
In your main Lovelace YAML configuration, under navbar-templates, add your custom template, using any of the card options:

```yaml
navbar-templates:
   your_template_name:
      # Your navbar config
      routes:
         - label: Home
           icon: mdi:home
           url: /lovelace/home
         ...
# Your normal lovelace configuration
views:
...
```

Then, from your dashboard, reference that newly created template:

```yaml
type: custom:navbard-card
template: your_template_name
```

For more information, check out the [templates](https://github.com/joseluis9595/lovelace-navbar-card?tab=readme-ov-file#templates) section in the docs.

<br>

---

<br>

### Changes in this release

#### Features
- New `template` parameter

---
**Full Changelog**: https://github.com/joseluis9595/lovelace-navbar-card/compare/v0.0.7...v0.1.0