### PR TITLE
Navbar in desktop mode, now correctly in center

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -60,7 +60,7 @@ const NAVBAR_STYLES = css`
     top: unset;
     right: unset;
     bottom: 16px;
-    left: 50%;
+    left: calc((100% + var(--mdc-drawer-width)) / 2);
     transform: translate(-50%, 0);
   }
   .navbar.desktop.top {
@@ -68,7 +68,7 @@ const NAVBAR_STYLES = css`
     bottom: unset;
     right: unset;
     top: 16px;
-    left: 50%;
+    left: calc((100% + var(--mdc-drawer-width)) / 2);
     transform: translate(-50%, 0);
   }
   .navbar.desktop.left {


### PR DESCRIPTION
We can also do: `left: calc(50% + var(--mdc-drawer-width) / 2)`
Let me know what you like.
Your previously suggested code made the navbar allign to far to the right.