### PR TITLE
Release/0.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 | Name      | Type                   | Default    | Description                                           |
 |-----------|------------------------|------------|-------------------------------------------------------|
 | `routes`  | [Routes](#routes)      | `Required` | Defines the array of routes to be shown in the navbar |
-| `template`| [Template](#templates) | -          | Template name                                         |
 | `desktop` | [Desktop](#desktop)    | -          | Options specific to desktop mode                      |
 | `mobile`  | [Mobile](#mobile)      | -          | Options specific to mobile mode                       |
+| `template`| [Template](#template) | -          | Template name                                         |
 | `styles`  | [Styles](#styles)      | -          | Custom CSS styles for the card                        |
 
 
@@ -59,15 +59,16 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 
 Routes represents an array of clickable icons that redirects to a given path. Each item in the array should contain the following configuration:
 
-| Name            	| Type            	 | Default    	| Description                                                     	                                        |
-|-----------------	|-----------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
-| `url`           	| string          	 | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                           |
-| `icon`          	| string          	 | `Required` 	| Material icon to display as this entry icon                     	                                        |
-| `icon_selected` 	| string          	 | -          	| Icon to be displayed when `url` matches the current browser URL 	                                        |
-| `badge`         	| [Badge](#badge) 	 | -          	| Badge configuration                                             	                                        |
-| `label`         	| string          	 | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
+| Name            	| Type            	                   | Default    	| Description                                                     	                                        |
+|-----------------	|------------------------------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
+| `url`           	| string          	                   | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                          |
+| `icon`          	| string          	                   | `Required` 	| Material icon to display as this entry icon                     	                                        |
+| `icon_selected` 	| string          	                   | -          	| Icon to be displayed when `url` matches the current browser URL 	                                        |
+| `badge`         	| [Badge](#badge) 	                   | -          	| Badge configuration                                             	                                        |
+| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
 | `tap_action`   	   | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
-| `submenu`         	| [Submenu](#submenu) | -          	| List of routes to display in a popup submenu                                                               |
+| `submenu`         	| [Submenu](#submenu)                   | -          	| List of routes to display in a popup submenu                                                               |
+| `hidden`         	| boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to render this route or not                                                               |
 
 > **Note**: `url` is required unless `tap_action` or `submenu` is present. If `tap_action` is defined, `url` is ignored. And if `submenu` is present, both `tap_action` and `url` are ignored.
 
@@ -78,28 +79,92 @@ Configuration to display a small badge on any of the navbar items.
 ![navbar-card-badge](https://github.com/user-attachments/assets/5f548ce3-82b5-422f-a084-715bc73846b0)
 
 
-| Name       	| Type        	| Default 	| Description                                                     	|
-|------------	|-------------	|---------	|-----------------------------------------------------------------	|
-| `template` 	| JS template 	| -       	| Boolean template indicating whether to display the badge or not 	|
-| `color`    	| string      	| red     	| Background color of the badge                                   	|
+| Name       	| Type        	                           | Default 	| Description                                                     	|
+|------------	|--------------------------------------	|---------	|-----------------------------------------------------------------	|
+| `show` 	   | boolean \| [JSTemplate](#jstemplate) 	| false    	| Boolean template indicating whether to display the badge or not 	|
+| `color`    	| string      	                           | red     	| Background color of the badge                                   	|
 
 #### Submenu
 
 For each route, a submenu can be configured, to display a popup when clicked. This action will have precedence over both `tap_action` and `url` when present.
 
-| Name            	| Type            	 | Default    	| Description                                                     	                                        |
-|-----------------	|-----------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
-| `url`           	| string          	 | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                           |
-| `icon`          	| string          	 | `Required` 	| Material icon to display as this entry icon                     	                                        |
-| `badge`         	| [Badge](#badge) 	 | -          	| Badge configuration                                             	                                        |
-| `label`         	| string          	 | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
+| Name            	| Type            	                   | Default    	| Description                                                     	                                        |
+|-----------------	|-----------------------------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
+| `url`           	| string          	                   | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                           |
+| `icon`          	| string          	                   | `Required` 	| Material icon to display as this entry icon                     	                                        |
+| `badge`         	| [Badge](#badge) 	                   | -          	| Badge configuration                                             	                                        |
+| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
 | `tap_action`   	   | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
 
 > **Note**: `url` is required unless `tap_action` is present. If `tap_action` is defined, `url` is ignored.
 
+
+#### JSTemplate
+
+You can easily customize some properties of the navbar-card by writing your own JavaScript rules. To do this, you simply wrap the value of the field that supports JSTemplates in `[[[` and `]]]`, then write the JavaScript code that determines the property's value.
+
+
+Apart from using plain javascript, you can access some predefined variables:
+- `states` -> Contains the global state of all entities in HomeAssistant. To get the state of a specific entity, use: `states['entity_type.your_entity'].state`.
+- `user` -> Information about the current logged user.
+- `hass` -> Complete hass object.
+
+> **Tip**: You can use `console.log` in your JSTemplate to help debug your HomeAssistant states.
+
+Below is an example using JSTemplates for displaying a route only for one user, and a label indicating the number of lights currently on:
+
+```yaml
+type: custom:navbar-card
+desktop:
+  position: bottom
+  show_labels: true
+routes:
+  - url: /lovelace/lights
+    label: |
+      [[[ 
+        const lightsOn = Object.entries(hass.states)
+          .filter(([entityId, value]) => {
+            return entityId.startsWith('light.') && value.state == 'on';
+          })
+          .length;
+        return `Lights (${lightsOn})` 
+      ]]]
+    icon: mdi:lightbulb-outline
+    icon_selected: mdi:lightbulb
+  - url: /lovelace/devices
+    label: Devices
+    icon: mdi:devices
+    hidden: |
+      [[[ return user.name != "jose"; ]]]  
+```
+
 ---
 
-### Templates
+### Desktop
+
+Specific configuration for desktop mode.
+
+| Name          | Type                                   | Default  | Description                                                                |
+|---------------|----------------------------------------|----------|----------------------------------------------------------------------------|
+| `show_labels` | boolean                                | `false`  | Whether or not to display labels under each route                          |
+| `min_width`   | number                                 | `768`    | Screen size from which the navbar will be displayed as its desktop variant |
+| `position`    | `top` \| `bottom` \| `left` \| `right` | `bottom` | Position of the navbar on desktop devices                                  |
+| `hidden`      | boolean \| [JSTemplate](#jstemplate)   | `false`  | Set to true to hide the navbar on desktop devices                          |
+
+---
+
+### Mobile
+
+Specific configuration for mobile mode.
+
+| Name          | Type                                 | Default | Description                                       |
+|---------------|------------------------------------  |---------|---------------------------------------------------|
+| `show_labels` | boolean                              | `false` | Whether or not to display labels under each route |
+| `hidden`      | boolean \| [JSTemplate](#jstemplate) | `false` | Set to true to hide the navbar on mobile devices  |
+
+---
+
+### Template
 
 Templates allow you to predefine a custom configuration for `navbar-card` and reuse it across multiple dashboards. This approach saves time and simplifies maintenance — any change to the template will automatically apply to all cards using it. 
 
@@ -151,30 +216,6 @@ styles: |
     --navbar-primary-color: red;
   }
 ```
-
----
-
-### Desktop
-
-Specific configuration for desktop mode.
-
-| Name          | Type                                   | Default  | Description                                                                |
-|---------------|----------------------------------------|----------|----------------------------------------------------------------------------|
-| `show_labels` | boolean                                | `false`  | Whether or not to display labels under each route                          |
-| `min_width`   | number                                 | `768`    | Screen size from which the navbar will be displayed as its desktop variant |
-| `position`    | `top` \| `bottom` \| `left` \| `right` | `bottom` | Position of the navbar on desktop devices                                  |
-| `hidden`      | boolean                                | `false`  | Set to true to hide the navbar on desktop devices                          |
-
----
-
-### Mobile
-
-Specific configuration for mobile mode.
-
-| Name          | Type    | Default | Description                                       |
-|---------------|---------|---------|---------------------------------------------------|
-| `show_labels` | boolean | `false` | Whether or not to display labels under each route |
-| `hidden`      | boolean | `false` | Set to true to hide the navbar on mobile devices  |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -60,7 +60,7 @@ const NAVBAR_STYLES = css`
     top: unset;
     right: unset;
     bottom: 16px;
-    left: 50%;
+    left: calc((100% + var(--mdc-drawer-width)) / 2);
     transform: translate(-50%, 0);
   }
   .navbar.desktop.top {
@@ -68,7 +68,7 @@ const NAVBAR_STYLES = css`
     bottom: unset;
     right: unset;
     top: 16px;
-    left: 50%;
+    left: calc((100% + var(--mdc-drawer-width)) / 2);
     transform: translate(-50%, 0);
   }
   .navbar.desktop.left {

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,17 +7,21 @@ export enum DesktopPosition {
   right = 'right',
 }
 
+type JSTemplate = string;
+
 export type RouteItem = {
   url: string;
   icon: string;
   icon_selected?: string;
-  label?: string;
+  label?: string | JSTemplate;
   badge?: {
-    template?: string;
+    template?: string; // TODO deprecate
     color?: string;
+    show?: boolean | JSTemplate;
   };
   tap_action?: ActionConfig;
   submenu?: PopupItem[];
+  hidden?: boolean | JSTemplate;
 };
 
 export type PopupItem = Omit<RouteItem, 'submenu' | 'icon_selected'>;
@@ -29,11 +33,11 @@ export type NavbarCardConfig = {
     show_labels?: boolean;
     min_width?: number;
     position?: DesktopPosition;
-    hidden?: boolean;
+    hidden?: boolean | JSTemplate;
   };
   mobile?: {
     show_labels?: boolean;
-    hidden?: boolean;
+    hidden?: boolean | JSTemplate;
   };
   styles?: string;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,12 @@
+import { HomeAssistant } from 'custom-card-helpers';
+
+/**
+ * Map string to enum value
+ *
+ * @param enumType Enum type to map to
+ * @param value Value to map
+ * @returns Enum value or undefined if not found
+ */
 export const mapStringToEnum = <T extends Record<string, any>>(
   enumType: T,
   value: string,
@@ -6,4 +15,51 @@ export const mapStringToEnum = <T extends Record<string, any>>(
     return value as T[keyof T];
   }
   return undefined;
+};
+
+/**
+ *  Badge visibility evaluator
+ */
+export const processBadgeTemplate = (
+  hass: HomeAssistant,
+  template?: string,
+): boolean => {
+  if (!template || !hass) return false;
+  try {
+    // Dynamically evaluate template with current Home Assistant context
+    const func = new Function('states', `return ${template}`);
+    return func(hass.states) as boolean;
+  } catch (e) {
+    console.warn(`NavbarCard: Error evaluating badge template: ${e}`);
+    return false;
+  }
+};
+
+/**
+ *  Process template with Home Assistant states
+ *
+ *  @param hass Home Assistant instance
+ *  @param template Template string to be processed
+ */
+export const processTemplate = (hass: HomeAssistant, template?: any) => {
+  if (!template || !hass) return template;
+
+  // Check if template is of type string
+  if (typeof template !== 'string') return template;
+
+  // Valid template starts with [[ and ends with ]]]
+  if (!(template.trim().startsWith('[[[') && template.trim().endsWith(']]]'))) {
+    return template;
+  }
+  console.log(template);
+
+  // Run template against home assistant states
+  try {
+    const cleanTemplate = template.replace(/\[\[\[|\]\]\]/g, '');
+    const func = new Function('states', cleanTemplate);
+    return func(hass.states);
+  } catch (e) {
+    console.warn(`NavbarCard: Error evaluating template: ${e}`);
+    return template;
+  }
 };


### PR DESCRIPTION
## Javascript templates

With this new release of navbar-card, some fields just got easier to customize! I've added support for custom Javascript templates in the following properties:

- `desktop` → `hidden`
- `mobile` → `hidden`
- `route` → `label`
- `route` → `hidden`
- `route` → `badge` → `show`

For all these properties, you can either provide the previous supported value, or wrap the value in `[[[` and `]]]` to write your own custom Javascript logic.

You can now, for example, display a route for only one user:

```yaml
type: custom:navbar-card
....
routes:
  ...
  - url: /lovelace/devices
    label: Devices
    icon: mdi:devices
    hidden: |
      [[[ return user.name != "jose"; ]]] 
```

Or change the label of a route to any value you want. In this example, showing all the lights that are on:

```yaml
type: custom:navbar-card
....
routes:
  ...
  - url: /lovelace/lights
    label: |
      [[[ 
        const lightsOn = Object.entries(hass.states)
          .filter(([entityId, value]) => {
            return entityId.startsWith('light.') && value.state == 'on';
          })
          .length;
        return `Lights (${lightsOn})` 
      ]]]
    icon: mdi:lightbulb-outline
    icon_selected: mdi:lightbulb
```

For more detailed information, check the [JSTemplates](https://github.com/joseluis9595/lovelace-navbar-card?tab=readme-ov-file#jstemplate) section

## Visibility options

As some of you may have noticed in the previous section, we can now configure the visibility of each route individually, via the `hidden` property. This change standardises the visibility option for most navbar-card items, using either a boolean value or a Javascript Template.

## ⚠️⚠️ Deprecated properties
In this new release, the property to configure when to display a badge, previously named `template`, has been deprecated in favor of `show`, now supporting either boolean value or Javascript Templates. 

This aims to, once again, standardise the visibility configurations across navbar-card.


<br>

---

<br>

## All changes in this release

#### Features
- New `hidden` prop for each route configuration
- Add support for JSTemplates

#### Fixes
- Fixed issue of navbar-card not being centered on desktop devices, when the HA's sidebar was open. By [SneakieGargamel](https://github.com/joseluis9595/lovelace-navbar-card/commits?author=SneakieGargamel) fixing [#17](https://github.com/joseluis9595/lovelace-navbar-card/issues/17). Thank you so much!

**Full Changelog**: https://github.com/joseluis9595/lovelace-navbar-card/compare/v0.2.0...v0.3.0