### PR TITLE
Release/0.4.0

### DIFF
--- a/.github/workflows/pr-main.yml
+++ b/.github/workflows/pr-main.yml
@@ -1,0 +1,34 @@
+name: Build & Test PR to main branch
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Extract version
+        id: get_version
+        run: echo "version=v$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+
+      - name: Check if tag already exists
+        id: check_tag
+        run: |
+          if git ls-remote --tags origin | grep -q "refs/tags/${{ steps.get_version.outputs.version }}$"; then
+            echo "Version ${{ steps.get_version.outputs.version }} already exists in this repo, please change package.json version before releasing"
+            exit 1
+          fi
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: |
+          bun install
+
+      - name: Build Project
+        run: bun run build

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
+# JS output files
 /node_modules/
 /dist
-*.log
 
+# Misc
+*.log
 TODO.txt
 
-navbar-card.js
+# OS specifics
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -59,16 +59,17 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 
 Routes represents an array of clickable icons that redirects to a given path. Each item in the array should contain the following configuration:
 
-| Name            	| Type            	                   | Default    	| Description                                                     	                                        |
-|-----------------	|------------------------------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
-| `url`           	| string          	                   | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                          |
-| `icon`          	| string          	                   | `Required` 	| Material icon to display as this entry icon                     	                                        |
-| `icon_selected` 	| string          	                   | -          	| Icon to be displayed when `url` matches the current browser URL 	                                        |
-| `badge`         	| [Badge](#badge) 	                   | -          	| Badge configuration                                             	                                        |
-| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
-| `tap_action`   	   | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
-| `submenu`         	| [Submenu](#submenu)                   | -          	| List of routes to display in a popup submenu                                                               |
-| `hidden`         	| boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to render this route or not                                                               |
+| Name            	| Type            	                    | Default    	| Description                                                     	                                        |
+|-----------------	|------------------------------------	  |------------	|---------------------------------------------------------------------------------------------------------- |
+| `url`           	| string          	                    | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                          |
+| `icon`          	| string          	                    | `Required` 	| Material icon to display as this entry icon                     	                                        |
+| `icon_selected` 	| string          	                    | -          	| Icon to be displayed when `url` matches the current browser URL 	                                        |
+| `badge`         	| [Badge](#badge) 	                    | -          	| Badge configuration                                             	                                        |
+| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                      |
+| `tap_action`   	  | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
+| `hold_action`	    | [hold_action](https://www.home-assistant.io/dashboards/actions/#hold_action) | -     | Custom hold action configuration.                                        |
+| `submenu`        	| [Submenu](#submenu)                   | -          	| List of routes to display in a popup submenu                                                              |
+| `hidden`         	| boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to render this route or not                                                              |
 
 > **Note**: `url` is required unless `tap_action` or `submenu` is present. If `tap_action` is defined, `url` is ignored. And if `submenu` is present, both `tap_action` and `url` are ignored.
 
@@ -94,7 +95,8 @@ For each route, a submenu can be configured, to display a popup when clicked. Th
 | `icon`          	| string          	                   | `Required` 	| Material icon to display as this entry icon                     	                                        |
 | `badge`         	| [Badge](#badge) 	                   | -          	| Badge configuration                                             	                                        |
 | `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
-| `tap_action`   	   | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
+| `tap_action`   	  | [tap_action](https://www.home-assistant.io/dashboards/actions/#tap_action) | -     | Custom tap action configuration. This setting disables the default navigate action.                   |
+| `hold_action`	    | [hold_action](https://www.home-assistant.io/dashboards/actions/#hold_action) | -     | Custom hold action configuration.                                        |
 
 > **Note**: `url` is required unless `tap_action` is present. If `tap_action` is defined, `url` is ignored.
 
@@ -336,6 +338,9 @@ routes:
   - icon: mdi:devices
     url: /lovelace/devices
     label: Devices
+    hold_action:
+      action: navigate
+      navigation_path: /config/devices/dashboard
   - icon: mdi:thermometer
     url: /lovelace/weather
     label: Weather

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.3.1",
+  "version": "0.4.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,7 @@ export type RouteItem = {
     show?: boolean | JSTemplate;
   };
   tap_action?: ActionConfig;
+  hold_action?: ActionConfig;
   submenu?: PopupItem[];
   hidden?: boolean | JSTemplate;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,3 +62,19 @@ export const processTemplate = (hass: HomeAssistant, template?: any) => {
     return template;
   }
 };
+
+export const fireDOMEvent = (
+  node: HTMLElement | Window,
+  type: Event['type'],
+  options?: { bubbles?: boolean; composed?: boolean },
+  detail?: any,
+) => {
+  const event = new Event(type, options ?? {});
+  (event as any).detail = detail;
+  node.dispatchEvent(event);
+  return event;
+};
+
+export const hapticFeedback = (hapticType: string = 'selection') => {
+  return fireDOMEvent(window, 'haptic', undefined, hapticType);
+};


### PR DESCRIPTION
## Custom Long press actions
In this new release of navbar-card, I've added support for customizing the **long press actions** for each route of the card. Same as `tap_action`, simply add a new entry `hold_action` to your route, following the [Home Assistant docs](https://www.home-assistant.io/dashboards/actions/#hold-action) specifications.

```yaml
type: custom:navbar-card
...
routes:
  ...
  - icon: mdi:devices
    url: /lovelace/devices
    label: Devices
    hold_action:
      action: navigate
      navigation_path: /config/devices/dashboard
````


<br>

---

<br>

### All changes in this release

- New `hold_action` config option for each route. (#26 )
- Added haptic feedback on click, when a route has custom `tap_action` or `submenu` configured.