### PR TITLE
fix: navbar not being properly centered with "position: bottom"  and …

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -60,7 +60,7 @@ const NAVBAR_STYLES = css`
     top: unset;
     right: unset;
     bottom: 16px;
-    left: calc((100% + var(--mdc-drawer-width)) / 2);
+    left: calc(50% + var(--mdc-drawer-width, 0px));
     transform: translate(-50%, 0);
   }
   .navbar.desktop.top {
@@ -68,7 +68,7 @@ const NAVBAR_STYLES = css`
     bottom: unset;
     right: unset;
     top: 16px;
-    left: calc((100% + var(--mdc-drawer-width)) / 2);
+    left: calc(50% + var(--mdc-drawer-width, 0px));
     transform: translate(-50%, 0);
   }
   .navbar.desktop.left {


### PR DESCRIPTION
- Fix navbar not being properly centered in desktop with "bottom" or "top" positions. (closes #30 )