### PR TITLE
Release/0.5.0

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -7,6 +7,10 @@ on:
 
 jobs:
   build-release:
+    permissions:
+      contents: write
+      deployments: write
+
     # Run only on Pull requests merged to main
     if: github.event.pull_request.merged == true && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 | `hold_action`	    | [hold_action](https://www.home-assistant.io/dashboards/actions/#hold_action) | -     | Custom hold action configuration.                                        |
 | `submenu`        	| [Submenu](#submenu)                   | -          	| List of routes to display in a popup submenu                                                              |
 | `hidden`         	| boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to render this route or not                                                              |
+| `selected`         | boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to display this route as selected or not. If not defined, the selected status will be computed as `route.url == window.location.pathname`|
 
 > **Note**: `url` is required unless `tap_action` or `submenu` is present. If `tap_action` is defined, `url` is ignored. And if `submenu` is present, both `tap_action` and `url` are ignored.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -216,7 +216,11 @@ export class NavbarCard extends LitElement {
    * Render route item
    */
   private _renderRoute = (route: RouteItem) => {
-    const isActive = this._location == route.url;
+    const isActive =
+      route.selected != null
+        ? processTemplate(this.hass, route.selected)
+        : this._location == route.url;
+
     let showBadge = false;
     if (route.badge?.show) {
       showBadge = processTemplate(this.hass, route.badge?.show);

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -60,7 +60,7 @@ const NAVBAR_STYLES = css`
     top: unset;
     right: unset;
     bottom: 16px;
-    left: calc((100% + var(--mdc-drawer-width)) / 2);
+    left: calc(50% + var(--mdc-drawer-width, 0px));
     transform: translate(-50%, 0);
   }
   .navbar.desktop.top {
@@ -68,7 +68,7 @@ const NAVBAR_STYLES = css`
     bottom: unset;
     right: unset;
     top: 16px;
-    left: calc((100% + var(--mdc-drawer-width)) / 2);
+    left: calc(50% + var(--mdc-drawer-width, 0px));
     transform: translate(-50%, 0);
   }
   .navbar.desktop.left {

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,6 +23,7 @@ export type RouteItem = {
   hold_action?: ActionConfig;
   submenu?: PopupItem[];
   hidden?: boolean | JSTemplate;
+  selected?: boolean | JSTemplate;
 };
 
 export type PopupItem = Omit<RouteItem, 'submenu' | 'icon_selected'>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,7 +30,7 @@ export const processBadgeTemplate = (
     const func = new Function('states', `return ${template}`);
     return func(hass.states) as boolean;
   } catch (e) {
-    console.warn(`NavbarCard: Error evaluating badge template: ${e}`);
+    console.error(`NavbarCard: Error evaluating badge template: ${e}`);
     return false;
   }
 };
@@ -58,7 +58,7 @@ export const processTemplate = (hass: HomeAssistant, template?: any) => {
     const func = new Function('states', 'user', 'hass', cleanTemplate);
     return func(hass.states, hass.user, hass);
   } catch (e) {
-    console.warn(`NavbarCard: Error evaluating template: ${e}`);
+    console.error(`NavbarCard: Error evaluating template: ${e}`);
     return template;
   }
 };


### PR DESCRIPTION
## New `selected` option for each route

With this new release, I've introduced a minor new configuration option for each route. You can now choose whether or not to show one route as selected via templates. 

This new option plays nicely with [anchor-card](https://github.com/ShadowAya/anchor-card), as mentioned in #27 

```yaml
type: custom:navbar-card
...
routes:
  ...
  - icon: mdi:home-outline
    icon_selected: mdi:home-assistant
    url: /lovelace/home?anchor=map
    label: Home
    selected: |
      [[[
        const matchesPath = window.location.pathname == "/lovelace/home"; 
        const hasAnchor = window.location.search.includes("anchor=map");
        return matchesPath && hasAnchor;
      ]]]
```
<br>

---

<br>

### All changes in this release

- New optional `selected` config for each route. #27 
- Fixed centering of navbar in desktop devices. #30 