### PR TITLE
Release/0.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![HA Community forum](https://img.shields.io/badge/Home%20Assistant-Community%20Forum-319fee?logo=home-assistant)](https://community.home-assistant.io/t/navbar-card-easily-navigate-through-dashboards/832917)
 
 # Navbar Card
+
 ![navbar-card](https://github.com/user-attachments/assets/df2a9a5d-51ec-4786-8f54-36ece2aa6f9a)
 
 Navbar Card is a custom Lovelace card designed to simplify navigation within your Home Assistant dashboard, heavily inspired by the great work of [Adaptive Mushroom](https://community.home-assistant.io/t/adaptive-mushroom/640308). It provides a sleek, responsive navigation bar that displays as a full-width bar at the bottom on mobile devices. On desktop, it adapts into a flexible container that can be positioned on any side of the screen (top, bottom, left, or right) adjusting its orientation to fit seamlessly.
@@ -17,9 +18,11 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 ## 🚀 Installation
 
 ### Open in HACS (recommended)
+
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=joseluis9595&repository=lovelace-navbar-card&category=plugin)
 
 ### HACS manual configuration
+
 1. Go to HACS in Home Assistant.
 2. On the top right, click "Custom repositories".
 3. Enter the repository URL: https://github.com/joseluis9595/lovelace-navbar-card.git
@@ -27,6 +30,7 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 5. Click Install!
 
 ### Manual
+
 1. Download [navbar-card.js](https://github.com/joseluis9595/lovelace-navbar-card/releases/latest/download/navbar-card.js) from the latest release.
 2. Move this file to home assistant's `<config>/www` folder.
 3. In home assistant, go to `Settings > Dashboards`.
@@ -36,7 +40,6 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
    - **Resource type**: JavaScript module
 6. Go to your dashboard, refresh your page and add your new navbar-card!
 
-
 <br>
 
 ---
@@ -45,53 +48,61 @@ Navbar Card is a custom Lovelace card designed to simplify navigation within you
 
 ## ⚙️ Configuration
 
-
-| Name      | Type                   | Default    | Description                                           |
-|-----------|------------------------|------------|-------------------------------------------------------|
-| `routes`  | [Routes](#routes)      | `Required` | Defines the array of routes to be shown in the navbar |
-| `desktop` | [Desktop](#desktop)    | -          | Options specific to desktop mode                      |
-| `mobile`  | [Mobile](#mobile)      | -          | Options specific to mobile mode                       |
-| `template`| [Template](#template) | -          | Template name                                         |
-| `styles`  | [Styles](#styles)      | -          | Custom CSS styles for the card                        |
-
+| Name       | Type                  | Default    | Description                                           |
+| ---------- | --------------------- | ---------- | ----------------------------------------------------- |
+| `routes`   | [Routes](#routes)     | `Required` | Defines the array of routes to be shown in the navbar |
+| `desktop`  | [Desktop](#desktop)   | -          | Options specific to desktop mode                      |
+| `mobile`   | [Mobile](#mobile)     | -          | Options specific to mobile mode                       |
+| `template` | [Template](#template) | -          | Template name                                         |
+| `styles`   | [Styles](#styles)     | -          | Custom CSS styles for the card                        |
 
 ### Routes
 
 Routes represents an array of clickable icons that redirects to a given path. Each item in the array should contain the following configuration:
 
-| Name            	| Type            	                    | Default    	| Description                                                     	                                        |
-|-----------------	|------------------------------------	  |------------	|---------------------------------------------------------------------------------------------------------- |
-| `url`           	| string          	                    | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                          |
-| `icon`          	| string          	                    | `Required` 	| Material icon to display as this entry icon                     	                                        |
-| `icon_selected` 	| string          	                    | -          	| Icon to be displayed when `url` matches the current browser URL 	                                        |
-| `badge`         	| [Badge](#badge) 	                    | -          	| Badge configuration                                             	                                        |
-| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                      |
-| `tap_action`   	  | [tap_action](#actions) | -     | Custom tap action configuration, including 'open-popup' to display a popup menu.                           |
-| `hold_action`	    | [hold_action](#actions) | -     | Custom hold action configuration, including 'open-popup' to display a popup menu.                          |
-| `popup`        	| [Popup items](#popup-items)           | -          	| List of routes to display in a popup menu                                                                 |
-| `hidden`         	| boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to render this route or not                                                              |
-| `selected`         | boolean \| [JSTemplate](#jstemplate)  | -          	| Controls whether to display this route as selected or not. If not defined, the selected status will be computed as `route.url == window.location.pathname`|
+| Name             | Type                                 | Default     | Description                                                                                                                                                |
+| ---------------- | ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `url`            | string                               | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                                                                           |
+| `icon`           | string                               | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
+| `icon_selected`  | string                               | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
+| `image`          | string                               | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
+| `image_selected` | string                               | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
+| `badge`          | [Badge](#badge)                      | -           | Badge configuration                                                                                                                                        |
+| `label`          | string \| [JSTemplate](#jstemplate)  | -           | Label to be displayed under the given route if `show_labels` is true                                                                                       |
+| `tap_action`     | [tap_action](#actions)               | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.                                                                           |
+| `hold_action`    | [hold_action](#actions)              | -           | Custom hold action configuration, including 'open-popup' to display a popup menu.                                                                          |
+| `popup`          | [Popup items](#popup-items)          | -           | List of routes to display in a popup menu                                                                                                                  |
+| `hidden`         | boolean \| [JSTemplate](#jstemplate) | -           | Controls whether to render this route or not                                                                                                               |
+| `selected`       | boolean \| [JSTemplate](#jstemplate) | -           | Controls whether to display this route as selected or not. If not defined, the selected status will be computed as `route.url == window.location.pathname` |
 
 > **Note**: `url` is required unless `tap_action` or `popup` is present. If `tap_action` is defined, `url` is ignored.
+
+> **Note**: Some suggestions when using the `image` property:
+>
+> 1. Place your custom images in the `<ha-config-folder>/www` directory
+> 2. Use images with a transparent background for best results
+> 3. Keep image dimensions squared for best results
 
 #### Actions
 
 Apart from the [standard Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) (navigate, call-service, etc.), `navbar-card` supports a custom action to open popup menus:
 
-| Action       | Description                                       | Required Parameters |
-|--------------|---------------------------------------------------|---------------------|
-| `open-popup` | Opens the popup menu defined in the route         | None                |
+| Action       | Description                               | Required Parameters |
+| ------------ | ----------------------------------------- | ------------------- |
+| `open-popup` | Opens the popup menu defined in the route | None                |
 
 Example:
+
 ```yaml
 tap_action:
-  action: open-popup  # Will open the popup menu defined for this route
+  action: open-popup # Will open the popup menu defined for this route
 ```
 
 Or:
+
 ```yaml
 hold_action:
-  action: open-popup  # Will open the popup menu when the route is held
+  action: open-popup # Will open the popup menu when the route is held
 ```
 
 ### Example with Open-Popup Action
@@ -145,34 +156,32 @@ Configuration to display a small badge on any of the navbar items.
 
 ![navbar-card-badge](https://github.com/user-attachments/assets/5f548ce3-82b5-422f-a084-715bc73846b0)
 
-
-| Name       	| Type        	                           | Default 	| Description                                                     	|
-|------------	|--------------------------------------	|---------	|-----------------------------------------------------------------	|
-| `show` 	   | boolean \| [JSTemplate](#jstemplate) 	| false    	| Boolean template indicating whether to display the badge or not 	|
-| `color`    	| string      	                           | red     	| Background color of the badge                                   	|
+| Name    | Type                                 | Default | Description                                                     |
+| ------- | ------------------------------------ | ------- | --------------------------------------------------------------- |
+| `show`  | boolean \| [JSTemplate](#jstemplate) | false   | Boolean template indicating whether to display the badge or not |
+| `color` | string                               | red     | Background color of the badge                                   |
 
 #### Popup Items
 
 For each route, a popup menu can be configured, to display a popup when clicked. This is activated using the `open-popup` action in either `tap_action` or `hold_action`.
 
-| Name            	| Type            	                   | Default    	| Description                                                     	                                        |
-|-----------------	|-----------------------------------	 |------------	|----------------------------------------------------------------------------------------------------------  |
-| `url`           	| string          	                   | `Required*`  | The path to a Lovelace view. Ignored if `tap_action` is defined.                                           |
-| `icon`          	| string          	                   | `Required` 	| Material icon to display as this entry icon                     	                                        |
-| `badge`         	| [Badge](#badge) 	                   | -          	| Badge configuration                                             	                                        |
-| `label`         	| string \| [JSTemplate](#jstemplate)   | -          	| Label to be displayed under the given route if `show_labels` is true                                       |
-| `tap_action`   	  | [tap_action](#actions) | -     | Custom tap action configuration, including 'open-popup' to display a popup menu.                            |
-| `hold_action`	    | [hold_action](#actions) | -     | Custom hold action configuration, including 'open-popup' to display a popup menu.                           |
+| Name          | Type                                | Default     | Description                                                                       |
+| ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
+| `url`         | string                              | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                  |
+| `icon`        | string                              | `Required`  | Material icon to display as this entry icon                                       |
+| `badge`       | [Badge](#badge)                     | -           | Badge configuration                                                               |
+| `label`       | string \| [JSTemplate](#jstemplate) | -           | Label to be displayed under the given route if `show_labels` is true              |
+| `tap_action`  | [tap_action](#actions)              | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.  |
+| `hold_action` | [hold_action](#actions)             | -           | Custom hold action configuration, including 'open-popup' to display a popup menu. |
 
 > **Note**: `url` is required unless `tap_action` is present. If `tap_action` is defined, `url` is ignored.
-
 
 #### JSTemplate
 
 You can easily customize some properties of the navbar-card by writing your own JavaScript rules. To do this, you simply wrap the value of the field that supports JSTemplates in `[[[` and `]]]`, then write the JavaScript code that determines the property's value.
 
-
 Apart from using plain javascript, you can access some predefined variables:
+
 - `states` -> Contains the global state of all entities in HomeAssistant. To get the state of a specific entity, use: `states['entity_type.your_entity'].state`.
 - `user` -> Information about the current logged user.
 
@@ -202,7 +211,7 @@ routes:
     label: Devices
     icon: mdi:devices
     hidden: |
-      [[[ return user.name != "jose"; ]]]  
+      [[[ return user.name != "jose"; ]]]
 ```
 
 ---
@@ -212,7 +221,7 @@ routes:
 Specific configuration for desktop mode.
 
 | Name          | Type                                   | Default  | Description                                                                |
-|---------------|----------------------------------------|----------|----------------------------------------------------------------------------|
+| ------------- | -------------------------------------- | -------- | -------------------------------------------------------------------------- |
 | `show_labels` | boolean                                | `false`  | Whether or not to display labels under each route                          |
 | `min_width`   | number                                 | `768`    | Screen size from which the navbar will be displayed as its desktop variant |
 | `position`    | `top` \| `bottom` \| `left` \| `right` | `bottom` | Position of the navbar on desktop devices                                  |
@@ -225,7 +234,7 @@ Specific configuration for desktop mode.
 Specific configuration for mobile mode.
 
 | Name          | Type                                 | Default | Description                                       |
-|---------------|------------------------------------  |---------|---------------------------------------------------|
+| ------------- | ------------------------------------ | ------- | ------------------------------------------------- |
 | `show_labels` | boolean                              | `false` | Whether or not to display labels under each route |
 | `hidden`      | boolean \| [JSTemplate](#jstemplate) | `false` | Set to true to hide the navbar on mobile devices  |
 
@@ -233,7 +242,7 @@ Specific configuration for mobile mode.
 
 ### Template
 
-Templates allow you to predefine a custom configuration for `navbar-card` and reuse it across multiple dashboards. This approach saves time and simplifies maintenance — any change to the template will automatically apply to all cards using it. 
+Templates allow you to predefine a custom configuration for `navbar-card` and reuse it across multiple dashboards. This approach saves time and simplifies maintenance — any change to the template will automatically apply to all cards using it.
 
 #### Defining Templates
 
@@ -254,6 +263,7 @@ views:
 ```
 
 #### Referencing Templates
+
 You can reference a template from your `navbar-card` using the template property:
 
 ```yaml
@@ -268,6 +278,7 @@ Card properties defined directly in the card will take priority over those inher
 For example, if you want to use a template called `your_template_name` but have one specific dashboard with a different primary color, your configurations might look like this:
 
 - Default Navbar for Most Views:
+
 ```yaml
 type: custom:navbar-card
 template: your_template_name
@@ -288,7 +299,7 @@ styles: |
 
 ### Styles
 
-Custom CSS styles can be applied to the Navbar Card to personalize its appearance and adapt it to your dashboard's design. Simply provide a CSS string targeting the relevant classes to style the navbar to your liking. 
+Custom CSS styles can be applied to the Navbar Card to personalize its appearance and adapt it to your dashboard's design. Simply provide a CSS string targeting the relevant classes to style the navbar to your liking.
 
 You can check out some examples [here](#examples-with-custom-styles) for inspiration.
 
@@ -296,29 +307,34 @@ You can check out some examples [here](#examples-with-custom-styles) for inspira
 
 Here is a breakdown of the CSS classes available for customization:
 
-* `.navbar`: Base component for the navbar.
-  * `.navbar.desktop`: Styling for the desktop version.
-  * `.navbar.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
-  * `.navbar.mobile`: Styling for the mobile version.
+- `.navbar`: Base component for the navbar.
+  - `.navbar.desktop`: Styling for the desktop version.
+  - `.navbar.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
+  - `.navbar.mobile`: Styling for the mobile version.
 
-* `.route`: Represents each route (or item) within the navbar.
+- `.route`: Represents each route (or item) within the navbar.
 
-* `.button`: Background element for each icon.
-  * `.button.active`: Applies when a route is selected.
+- `.button`: Background element for each icon.
+  - `.button.active`: Applies when a route is selected.
 
-* `.icon`: Refers to the ha-icon component used for displaying icons.
+- `.icon`: Refers to the ha-icon component used for displaying icons.
+  - `.icon.active`: Applies when a route is selected.
 
-* `.label`: Text label displayed under the icons (if labels are enabled).
+- `.image`: Refers to the img component used for displaying route images.
+  - `.image.active`: Applies when a route is selected.
 
-* `.badge`: Small indicator or badge that appears over the icon (if configured).
+- `.label`: Text label displayed under the icons (if labels are enabled).
+  - `.label.active`: Applies when a route is selected.
 
-* `.navbar-popup-backdrop`: Backdrop styles for the popup.
+- `.badge`: Small indicator or badge that appears over the icon (if configured).
+  - `.badge.active`: Applies when a route is selected.
 
-* `.popup-item`: Styles applied to the container of each popup-item. This object contains both the "button" with the icon, and the label.
-  * `.popup-item.label-[top | bottom | left | right]`: Specific styles for different positions of the label.
-  * `.popup-item .label`: Styles applied to the label of each popup item.
-  * `.popup-item .button`: Button for each popup item, containing just the icon.
+- `.navbar-popup-backdrop`: Backdrop styles for the popup.
 
+- `.popup-item`: Styles applied to the container of each popup-item. This object contains both the "button" with the icon, and the label.
+  - `.popup-item.label-[top | bottom | left | right]`: Specific styles for different positions of the label.
+  - `.popup-item .label`: Styles applied to the label of each popup item.
+  - `.popup-item .button`: Button for each popup item, containing just the icon.
 
 <br>
 
@@ -328,12 +344,11 @@ Here is a breakdown of the CSS classes available for customization:
 
 ## 🛠️ Dashboard adjustements (Optional)
 
-### Padding 
+### Padding
 
 If you're using the Navbar Card, you might notice it could collide with other cards on your dashboard. A simple way to fix this is by adding some padding to your Home Assistant views. The easiest way to do that is by using [card-mod](https://github.com/thomasloven/lovelace-card-mod) with a [custom theme](https://www.home-assistant.io/integrations/frontend/#themes).
 
 Here's an example of how you can tweak your theme to adjust the layout for both desktop and mobile:
-
 
 ```yaml
 your_theme:
@@ -385,6 +400,7 @@ your_theme:
 <br>
 
 ## 📚 Example Configurations
+
 <details open>
 <summary open>Basic example</summary>
 
@@ -435,6 +451,7 @@ routes:
         [[[ states['binary_sensor.docker_hub_update_available'].state === 'on' ]]]
       color: var(--primary-color)
 ```
+
 </details>
 
 #### Examples with custom styles
@@ -457,7 +474,9 @@ styles: |
     --navbar-primary-color: red;
   }
 ```
+
 ![custom_primary_colors](https://github.com/user-attachments/assets/e2656904-4def-4b48-9e13-0a6f582bf12f)
+
 </details>
 
 <details>
@@ -478,7 +497,9 @@ styles: |
     background: #000000;
   }
 ```
+
 ![custom_background](https://github.com/user-attachments/assets/106ef845-b67d-4244-9f32-a0591934bce5)
+
 </details>
 
 <details>
@@ -499,7 +520,9 @@ styles: |
     border-radius: 0px;
   }
 ```
+
 ![border_radius](https://github.com/user-attachments/assets/ca6d0a48-5625-4f0a-9418-72cae54b9fe5)
+
 </details>
 
 <details>
@@ -522,5 +545,55 @@ styles: |
     bottom: 100px;
   }
 ```
+
 ![bottom_padding](https://github.com/user-attachments/assets/b08cab6b-c978-48af-8fb3-57d2d0599925)
+
+</details>
+
+<details>
+<summary>Display route only for a given user</summary>
+
+```yaml
+type: custom:navbar-card
+desktop:
+  position: bottom
+routes:
+  - url: /lovelace/home
+    label: Home
+    icon: mdi:home-outline
+    icon_selected: mdi:home-assistant
+  - url: /lovelace/devices
+    label: Devices
+    icon: mdi:devices
+  - url: /lovelace/settings
+    label: Settings
+    icon: mdi:cog
+    # This route will only be displayed for user "jose"
+    show: |
+      [[[ return user.name == "jose"]]] 
+```
+
+</details>
+
+<details>
+<summary>Force one route to always be selected</summary>
+
+```yaml
+type: custom:navbar-card
+desktop:
+  position: bottom
+routes:
+  - url: /lovelace/home
+    label: Home
+    selected: true      # force `selected` field to true
+    icon: mdi:home-outline
+    icon_selected: mdi:home-assistant
+  - url: /lovelace/devices
+    label: Devices
+    icon: mdi:devices
+  - url: /lovelace/settings
+    label: Settings
+    icon: mdi:cog
+```
+
 </details>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -4,6 +4,7 @@ const HOST_STYLES = css`
   :host {
     --navbar-background-color: var(--card-background-color);
     --navbar-route-icon-size: 24px;
+    --navbar-route-image-size: 32px;
     --navbar-primary-color: var(--primary-color);
     --navbar-box-shadow: 0px -1px 4px 0px rgba(0, 0, 0, 0.14);
     --navbar-box-shadow-desktop: var(--material-shadow-elevation-2dp);
@@ -127,9 +128,18 @@ const ROUTE_STYLES = css`
     --icon-primary-color: var(--navbar-primary-color);
   }
 
-  /* Icon styling */
+  /* Icon and Image styling */
   .icon {
     --mdc-icon-size: var(--navbar-route-icon-size);
+  }
+
+  .image {
+    width: var(--navbar-route-image-size);
+    height: var(--navbar-route-image-size);
+    object-fit: contain;
+  }
+
+  .image.active {
   }
 
   /* Label styling */
@@ -138,9 +148,8 @@ const ROUTE_STYLES = css`
     width: 100%;
     /* TODO fix ellipsis*/
     text-align: center;
-    font-size: var(--paper-font-caption_-_font-size);
+    font-size: var(--paper-font-caption_-_font-size, 12px);
     font-weight: 500;
-    font-family: var(--paper-font-caption_-_font-size);
   }
 
   /* Badge styling */

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,8 +19,10 @@ type JSTemplate = string;
 
 // Base properties shared by all route items
 interface RouteItemBase {
-  icon: string;
+  icon?: string;
+  image?: string;
   icon_selected?: string;
+  image_selected?: string;
   label?: string | JSTemplate;
   badge?: {
     template?: string; // TODO deprecate
@@ -36,7 +38,7 @@ export type PopupItem = RouteItemBase & {
   url?: string;
   tap_action?: ExtendedActionConfig;
   hold_action?: ExtendedActionConfig;
-}
+};
 
 // Main route item type
 export type RouteItem = RouteItemBase & {
@@ -46,7 +48,7 @@ export type RouteItem = RouteItemBase & {
   popup?: PopupItem[];
   // Alias for backward compatibility
   submenu?: PopupItem[];
-}
+};
 
 export type NavbarCardConfig = {
   routes: RouteItem[];


### PR DESCRIPTION
## Add your custom images to each route

This new release comes with a small but useful feature. The ability to add your own custom images to replace the icon of a given route. Easiest way is to store your custom images in the `<config>/www` folder of home assistant, and then reference said images with `/local/<image_name>`.

![Screenshot 2025-05-01 at 11 18 14](https://github.com/user-attachments/assets/e14e3a2f-78ed-4b52-8d99-a876f50cb46c)

```yaml
type: custom:navbar-card
...
routes:
  ...
  - url: /config/automation/dashboard
    image: /local/your_image.jpg
```

<br>

---

<br>

### All changes in this release
- New configuration option to add custom images to each route. (closes #18)
