### PR TITLE
Add navbar toggling

### DIFF
--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -577,6 +577,12 @@ export class NavbarCard extends LitElement {
           this._openPopup(popupItems, target);
         }, 100);
       }
+    } else if (route.tap_action?.action === 'toggle-menu'){
+      fireDOMEvent(
+        this,
+        'hass-toggle-menu', 
+        { bubbles: true, composed: true}
+      );
     } else if (route.tap_action != null) {
       hapticFeedback();
       fireDOMEvent(


### PR DESCRIPTION
Add option to toggle the native home-assistant nvabar. Usefull if the top app bar is hidden with tools like wallpanel or kiosk mode