### PR TITLE
Release/0.12.1

### DIFF
--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,4 +1,4 @@
-import { NavbarCardConfig } from './types';
+import { NavbarCardConfig, RippleElement } from './types';
 
 /**
  * Get a list of user defined navbar-card templates
@@ -27,15 +27,12 @@ export const getNavbarTemplates = (): Record<
  * @param target - The HTMLElement containing the md-ripple element
  */
 export const forceResetRipple = (target: HTMLElement) => {
-  const ripple = target?.querySelector('md-ripple');
-  if (ripple != null) {
+  const rippleElements = target?.querySelectorAll('ha-ripple');
+
+  rippleElements.forEach((ripple: RippleElement) => {
     setTimeout(() => {
-      ripple.shadowRoot
-        ?.querySelector('.surface')
-        ?.classList?.remove('hovered');
-      ripple.shadowRoot
-        ?.querySelector('.surface')
-        ?.classList?.remove('pressed');
+      ripple.hovered = false;
+      ripple.pressed = false;
     }, 10);
-  }
+  });
 };

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -49,7 +49,6 @@ const PROPS_TO_FORCE_UPDATE = [
   '_inEditDashboardMode',
   '_inEditCardMode',
   '_inPreviewMode',
-  '_location',
   '_popup',
 ];
 
@@ -66,7 +65,6 @@ export class NavbarCard extends LitElement {
   @state() private _inEditCardMode?: boolean;
   @state() private _inPreviewMode?: boolean;
   @state() private _lastRender?: number;
-  @state() private _location?: string;
   @state() private _popup?: TemplateResult | null;
 
   // hold_action state variables
@@ -91,9 +89,6 @@ export class NavbarCard extends LitElement {
 
     // Quick fix for ripple effects
     forceResetRipple(this);
-
-    // Initialize location
-    this._location = window.location.pathname;
 
     // Initialize screen size listener
     window.addEventListener('resize', this._checkDesktop);
@@ -310,6 +305,43 @@ export class NavbarCard extends LitElement {
   }
 
   /**********************************************************************/
+  /* Utils */
+  /**********************************************************************/
+  private _shouldTriggerHaptic(
+    actionType: 'tap' | 'hold' | 'double_tap',
+    isNavigation = false,
+  ): boolean {
+    const hapticConfig = this._config?.haptic;
+
+    // If haptic is a boolean, use it as a global setting
+    if (typeof hapticConfig === 'boolean') {
+      return hapticConfig;
+    }
+
+    // If no haptic config is provided, return default values
+    if (!hapticConfig) {
+      return !isNavigation;
+    }
+
+    // Check navigation first
+    if (isNavigation) {
+      return hapticConfig.url ?? false;
+    }
+
+    // Check specific action types
+    switch (actionType) {
+      case 'tap':
+        return hapticConfig.tap_action ?? false;
+      case 'hold':
+        return hapticConfig.hold_action ?? false;
+      case 'double_tap':
+        return hapticConfig.double_tap_action ?? false;
+      default:
+        return false;
+    }
+  }
+
+  /**********************************************************************/
   /* Navbar callbacks */
   /**********************************************************************/
 
@@ -344,7 +376,7 @@ export class NavbarCard extends LitElement {
     const isActive =
       route.selected != null
         ? processTemplate(this.hass, route.selected)
-        : this._location == route.url;
+        : window.location.pathname == route.url;
 
     if (processTemplate(this.hass, route.hidden)) {
       return null;
@@ -555,7 +587,7 @@ export class NavbarCard extends LitElement {
   };
 
   /**********************************************************************/
-  /* Event listenrs */
+  /* Event listeners */
   /**********************************************************************/
   private _onPopupKeyDownListener = (e: KeyboardEvent) => {
     if (e.key === 'Escape' && this._popup) {
@@ -816,40 +848,6 @@ export class NavbarCard extends LitElement {
       ${getDefaultStyles()}
       ${userStyles}
     `;
-  }
-
-  private _shouldTriggerHaptic(
-    actionType: 'tap' | 'hold' | 'double_tap',
-    isNavigation = false,
-  ): boolean {
-    const hapticConfig = this._config?.haptic;
-
-    // If haptic is a boolean, use it as a global setting
-    if (typeof hapticConfig === 'boolean') {
-      return hapticConfig;
-    }
-
-    // If no haptic config is provided, return default values
-    if (!hapticConfig) {
-      return !isNavigation;
-    }
-
-    // Check navigation first
-    if (isNavigation) {
-      return hapticConfig.url ?? false;
-    }
-
-    // Check specific action types
-    switch (actionType) {
-      case 'tap':
-        return hapticConfig.tap_action ?? false;
-      case 'hold':
-        return hapticConfig.hold_action ?? false;
-      case 'double_tap':
-        return hapticConfig.double_tap_action ?? false;
-      default:
-        return false;
-    }
   }
 }
 

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -13,6 +13,7 @@ import {
   DesktopPosition,
   NavbarCardConfig,
   PopupItem,
+  RippleElement,
   RouteItem,
 } from './types';
 import {
@@ -385,22 +386,25 @@ export class NavbarCard extends LitElement {
     return html`
       <div
         class="route ${isActive ? 'active' : ''}"
+        @mouseenter=${(e: PointerEvent) => this._handleMouseEnter(e, route)}
+        @mousemove=${(e: PointerEvent) => this._handleMouseMove(e, route)}
+        @mouseleave=${(e: PointerEvent) => this._handleMouseLeave(e, route)}
         @pointerdown=${(e: PointerEvent) => this._handlePointerDown(e, route)}
         @pointermove=${(e: PointerEvent) => this._handlePointerMove(e, route)}
         @pointerup=${(e: PointerEvent) => this._handlePointerUp(e, route)}
         @pointercancel=${(e: PointerEvent) =>
           this._handlePointerMove(e, route)}>
-        ${this._renderBadge(route, isActive)}
-
         <div class="button ${isActive ? 'active' : ''}">
           ${this._getRouteIcon(route, isActive)}
-          <md-ripple></md-ripple>
+          <ha-ripple></ha-ripple>
         </div>
+
         ${this._shouldShowLabels(false)
           ? html`<div class="label ${isActive ? 'active' : ''}">
               ${processTemplate(this.hass, route.label) ?? ' '}
             </div>`
           : html``}
+        ${this._renderBadge(route, isActive)}
       </div>
     `;
   };
@@ -541,8 +545,6 @@ export class NavbarCard extends LitElement {
               style="--index: ${index}"
               @click=${(e: MouseEvent) =>
                 this._handlePointerUp(e as PointerEvent, popupItem, true)}>
-              ${this._renderBadge(popupItem, false)}
-
               <div class="button">
                 ${this._getRouteIcon(popupItem, false)}
                 <md-ripple></md-ripple>
@@ -552,6 +554,7 @@ export class NavbarCard extends LitElement {
                     ${processTemplate(this.hass, popupItem.label) ?? ' '}
                   </div>`
                 : html``}
+              ${this._renderBadge(popupItem, false)}
             </div>`;
           })
           .filter(x => x != null)}
@@ -599,6 +602,27 @@ export class NavbarCard extends LitElement {
   /**********************************************************************/
   /* Pointer event listenrs */
   /**********************************************************************/
+  private _handleMouseEnter = (e: MouseEvent, _route: RouteItem) => {
+    const ripple = (e.currentTarget as HTMLElement).querySelector(
+      'ha-ripple',
+    ) as RippleElement;
+    if (ripple) ripple.hovered = true;
+  };
+
+  private _handleMouseMove = (e: MouseEvent, _route: RouteItem) => {
+    const ripple = (e.currentTarget as HTMLElement).querySelector(
+      'ha-ripple',
+    ) as RippleElement;
+    if (ripple) ripple.hovered = true;
+  };
+
+  private _handleMouseLeave = (e: MouseEvent, _route: RouteItem) => {
+    const ripple = (e.currentTarget as HTMLElement).querySelector(
+      'ha-ripple',
+    ) as RippleElement;
+    if (ripple) ripple.hovered = false;
+  };
+
   private _handlePointerDown = (e: PointerEvent, route: RouteItem) => {
     // Store the starting position for movement detection
     this.pointerStartX = e.clientX;
@@ -852,17 +876,23 @@ export class NavbarCard extends LitElement {
 }
 
 console.info(
-  `%c navbar-card %c ${version} `,
+  `%c navbar-card%cv${version} `,
   // Card name styles
-  'background-color: #555;\
-      padding: 6px 4px;\
-      color: #fff;\
-      text-shadow: 0 1px 0 rgba(1, 1, 1, 0.3); \
-      border-radius: 10px 0 0 10px;',
+  `background-color: #555;
+      padding: 6px 8px;
+      padding-right: 6px;
+      color: #fff;
+      font-weight: 800;
+      font-family: 'Segoe UI', Roboto, system-ui, sans-serif;
+      text-shadow: 0 1px 0 rgba(1, 1, 1, 0.3); 
+      border-radius: 16px 0 0 16px;`,
   // Card version styles
-  'background-color: #00abd1; \
-      padding: 6px 4px;\
-      color: #fff;\
-      text-shadow: 0 1px 0 rgba(1, 1, 1, 0.3); \
-      border-radius: 0 10px 10px 0;',
+  `background-color:rgb(0, 135, 197);
+      padding: 6px 8px;
+      padding-left: 6px;
+      color: #fff;
+      font-weight: 800;
+      font-family: 'Segoe UI', Roboto, system-ui, sans-serif;
+      text-shadow: 0 1px 0 rgba(1, 1, 1, 0.3); 
+      border-radius: 0 16px 16px 0;`,
 );

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -107,6 +107,7 @@ const ROUTE_STYLES = css`
 
   /* Button styling */
   .button {
+    position: relative;
     height: 36px;
     width: 100%;
     border-radius: 16px;
@@ -150,21 +151,21 @@ const ROUTE_STYLES = css`
 
   /* Badge styling */
   .badge {
-    border-radius: 999px;
-    width: 12px;
-    height: 12px;
     position: absolute;
     top: 0;
     right: 0;
+    border-radius: 999px;
+    width: 12px;
+    height: 12px;
   }
   .badge.with-counter {
-    min-width: 16px;
-    width: auto !important;
-    padding: 0px 2px;
-    height: 16px;
     display: flex;
-    align-items: center;
     justify-content: center;
+    align-items: center;
+    height: 16px;
+    width: auto !important;
+    min-width: 16px;
+    padding: 0px 2px;
     font-weight: bold;
     font-size: 11px;
     line-height: 11px;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,10 @@
 import { ActionConfig } from 'custom-card-helpers';
 
+export type RippleElement = Element & {
+  hovered?: boolean;
+  pressed?: boolean;
+};
+
 export enum DesktopPosition {
   top = 'top',
   left = 'left',


### PR DESCRIPTION
Today’s release brings just a couple of small fixes to improve the overall experience.

## Hover effect

On desktop devices, when using `navbar-card` with labels, the hover effect previously targetted the whole route, including the label and button. In some cases, the label would even overflow beyond the hover highlight, resulting in a poor visual experience.

Previous hover effect:
<img width="466" height="109" alt="previous-hover" src="https://github.com/user-attachments/assets/7e850d11-e5c1-40ef-bff0-457146bae149" />

Updated version:
<img width="466" height="109" alt="new-hover" src="https://github.com/user-attachments/assets/05d4504a-e88e-41ea-a16e-ceb07cbadf25" />

## Current route not selected

In certain scenarios—such as navigating to a native Home Assistant page and then returning to your custom dashboard—routes would not appear selected even though the URL matched. This release resolves that issue, ensuring the correct route is marked as active when appropriate.

Previous behaviour:
![navbar-card-route-selected](https://github.com/user-attachments/assets/f04e9367-902d-47d7-a648-8b88b667b8da)


<br>

---

<br>

#### All changes on this release

- Fix ripple effect on desktop devices.
- Fix route noy updating its `selected` state properly. (closes #83 )