### PR TITLE
Release/0.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.12.1",
+  "version": "0.12.2",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -789,17 +789,19 @@ export class NavbarCard extends LitElement {
       if (this._shouldTriggerHaptic(actionType)) {
         hapticFeedback();
       }
-      fireDOMEvent(
-        this,
-        'hass-action',
-        { bubbles: true, composed: true },
-        {
-          action: actionType,
-          config: {
-            [`${actionType}_action`]: action,
+      setTimeout(() => {
+        fireDOMEvent(
+          this,
+          'hass-action',
+          { bubbles: true, composed: true },
+          {
+            action: actionType,
+            config: {
+              [`${actionType}_action`]: action,
+            },
           },
-        },
-      );
+        );
+      }, 10);
     } else if (actionType === 'tap' && route.url) {
       // Handle default navigation for tap action if no specific action is defined
       if (this._shouldTriggerHaptic(actionType, true)) {


### PR DESCRIPTION
## `tap_action` not being triggered on some Android devices

As some of you suggested, on some Android devices, specially tablets, some `tap_actions` were not being triggered, unless the route was actually held for a few seconds. It was narrowed down to `browser_mod` actions specifically, and this release aims to finally fix it.

<br>

---

<br>

#### All changes in this release
- Fix `tap_action` not being triggered on some Android devices. (closes #80)