### PR TITLE
Release/0.13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Navbar Card is a custom Lovelace card designed to **simplify navigation** within
 <br>
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=joseluis9595&repository=lovelace-navbar-card&category=plugin)
-   
+
 </details>
 
 <details>
@@ -100,7 +100,6 @@ routes:
 ## ⚙️ Configuration
 
 <img width="400" height="120" alt="navbar-card" src="https://github.com/user-attachments/assets/346a6466-1a79-400e-9fe4-4f8472b3bee5" />
-
 
 | Name       | Type                  | Default    | Description                                                  |
 | ---------- | --------------------- | ---------- | ------------------------------------------------------------ |
@@ -174,7 +173,6 @@ Configuration to display a small badge on any of the navbar items.
 
 <img width="400" height="120" alt="navbar-card_badges" src="https://github.com/user-attachments/assets/44824ecd-9088-44c3-bab1-d900edeea614" />
 
-
 | Name        | Type                                 | Default | Description                                                     |
 | ----------- | ------------------------------------ | ------- | --------------------------------------------------------------- |
 | `show`      | boolean \| [JSTemplate](#jstemplate) | false   | Boolean template indicating whether to display the badge or not |
@@ -187,7 +185,6 @@ Configuration to display a small badge on any of the navbar items.
 For each route, a popup menu can be configured, to display a popup when clicked. This is activated using the `open-popup` action in either `tap_action` or `hold_action`.
 
 <img width="431" height="218" alt="navbar-card_popup" src="https://github.com/user-attachments/assets/520d85c7-9d73-4e73-b3c3-a4a6b2635dcb" />
-
 
 | Name          | Type                                | Default     | Description                                                                       |
 | ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
@@ -208,6 +205,8 @@ Apart from using plain javascript, you can access some predefined variables:
 
 - `states` -> Contains the global state of all entities in HomeAssistant. To get the state of a specific entity, use: `states['entity_type.your_entity'].state`.
 - `user` -> Information about the current logged user.
+- `navbar` -> Internal state of the navbar-card. Accessible fields are:
+  - `isDesktop` -> Boolean indicating whether the card is in its desktop variant or not.
 
 > **Tip**: You can use `console.log` in your JSTemplate to help debug your HomeAssistant states.
 
@@ -231,6 +230,8 @@ routes:
       ]]]
     icon: mdi:lightbulb-outline
     icon_selected: mdi:lightbulb
+    hidden: |
+      [[[ return navbar.isDesktop; ]]]
   - url: /lovelace/devices
     label: Devices
     icon: mdi:devices
@@ -349,7 +350,6 @@ You can check out some examples [here](#examples-with-custom-styles) for inspira
 Here is a breakdown of the CSS classes available for customization:
 
 - `.navbar`: Base component for the navbar.
-
   - `.navbar.desktop`: Styling for the desktop version.
   - `.navbar.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
   - `.navbar.mobile`: Styling for the mobile version.
@@ -357,23 +357,18 @@ Here is a breakdown of the CSS classes available for customization:
 - `.route`: Represents each route (or item) within the navbar.
 
 - `.button`: Background element for each icon.
-
   - `.button.active`: Applies when a route is selected.
 
 - `.icon`: Refers to the ha-icon component used for displaying icons.
-
   - `.icon.active`: Applies when a route is selected.
 
 - `.image`: Refers to the img component used for displaying route images.
-
   - `.image.active`: Applies when a route is selected.
 
 - `.label`: Text label displayed under the icons (if labels are enabled).
-
   - `.label.active`: Applies when a route is selected.
 
 - `.badge`: Small indicator or badge that appears over the icon (if configured).
-
   - `.badge.active`: Applies when a route is selected.
 
 - `.navbar-popup`: Main container for the popup.
@@ -465,7 +460,6 @@ your_theme:
 ---
 
 <br>
-
 
 ## 📚 Example Configurations
 
@@ -666,8 +660,6 @@ routes:
 
 </details>
 
-
-
 <br>
 
 ---
@@ -683,10 +675,9 @@ Need help using `navbar-card`, have ideas, or found a bug? Here's how you can re
 
 - **💬 Have questions, want to share feedback, or just chat?**<br>
   Either start [a discussion on GitHub](https://github.com/joseluis9595/lovelace-navbar-card/discussions) or join the conversation on the [Home Assistant Community Forum
-](https://community.home-assistant.io/t/navbar-card-easily-navigate-through-dashboards/832917).
+  ](https://community.home-assistant.io/t/navbar-card-easily-navigate-through-dashboards/832917).
 
 Your feedback helps make navbar-card better for everyone. Don’t hesitate to reach out!
-
 
 <br>
 
@@ -698,7 +689,6 @@ Your feedback helps make navbar-card better for everyone. Don’t hesitate to re
 
 If you enjoy using `navbar-card` and want to support its continued development, consider buying me a coffee (or a beer 🍺), or becoming a GitHub Sponsor!
 
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_a_Beer-fdd734?&logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/joseluis9595)  [![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-30363d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/joseluis9595)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_a_Beer-fdd734?&logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/joseluis9595) [![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-30363d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/joseluis9595)
 
 Your support means a lot and helps keep the project alive and growing. Thank you! 🙌
-

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 | Name                | Type                                 | Default     | Description                                                                                                                                                |
 | ------------------- | ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`               | string                               | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                                                                           |
-| `icon`              | string                               | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
-| `icon_selected`     | string                               | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
-| `image`             | string                               | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
-| `image_selected`    | string                               | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
+| `icon`              | string \| [JSTemplate](#jstemplate) | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
+| `icon_selected`     | string \| [JSTemplate](#jstemplate) | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
+| `image`             | string \| [JSTemplate](#jstemplate) | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
+| `image_selected`    | string \| [JSTemplate](#jstemplate) | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
 | `badge`             | [Badge](#badge)                      | -           | Badge configuration                                                                                                                                        |
 | `label`             | string \| [JSTemplate](#jstemplate)  | -           | Label to be displayed under the given route if `show_labels` is true                                                                                       |
 | `tap_action`        | [tap_action](#actions)               | -           | Custom tap action configuration.                                                                                                                           |
@@ -189,7 +189,7 @@ For each route, a popup menu can be configured, to display a popup when clicked.
 | Name          | Type                                | Default     | Description                                                                       |
 | ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
 | `url`         | string                              | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                  |
-| `icon`        | string                              | `Required`  | Material icon to display as this entry icon                                       |
+| `icon`        | string \| [JSTemplate](#jstemplate) | `Required`  | Material icon to display as this entry icon                                       |
 | `badge`       | [Badge](#badge)                     | -           | Badge configuration                                                               |
 | `label`       | string \| [JSTemplate](#jstemplate) | -           | Label to be displayed under the given route if `show_labels` is true              |
 | `tap_action`  | [tap_action](#actions)              | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.12.3",
+  "version": "0.13.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -252,18 +252,27 @@ export class NavbarCard extends LitElement {
   /* Subcomponents */
   /**********************************************************************/
   private _getRouteIcon(route: RouteItem | PopupItem, isActive: boolean) {
-    return route.image
+    const icon = processTemplate<string>(this.hass, this, route.icon);
+    const image = processTemplate<string>(this.hass, this, route.image);
+    const iconSelected = processTemplate<string>(
+      this.hass,
+      this,
+      route.icon_selected,
+    );
+    const imageSelected = processTemplate<string>(
+      this.hass,
+      this,
+      route.image_selected,
+    );
+
+    return image
       ? html`<img
           class="image ${isActive ? 'active' : ''}"
-          src="${isActive && route.image_selected
-            ? route.image_selected
-            : route.image}"
+          src="${isActive && imageSelected ? imageSelected : image}"
           alt="${route.label || ''}" />`
       : html`<ha-icon
           class="icon ${isActive ? 'active' : ''}"
-          icon="${isActive && route.icon_selected
-            ? route.icon_selected
-            : route.icon}"></ha-icon>`;
+          icon="${isActive && iconSelected ? iconSelected : icon}"></ha-icon>`;
   }
 
   private _renderBadge(route: RouteItem | PopupItem, isRouteActive: boolean) {
@@ -876,7 +885,6 @@ export class NavbarCard extends LitElement {
       return html``;
     }
 
-    // TODO use HA ripple effect for icon button
     return html`
       <ha-card
         class="navbar ${editModeClassname} ${deviceModeClassName} ${desktopPositionClassname}">

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -51,7 +51,7 @@ const HOLD_ACTION_DELAY = 500;
 export class NavbarCard extends LitElement {
   @state() protected hass!: HomeAssistant;
   @state() private _config?: NavbarCardConfig;
-  @state() private _isDesktop?: boolean;
+  @state() _isDesktop?: boolean;
   @state() private _inEditDashboardMode?: boolean;
   @state() private _inEditCardMode?: boolean;
   @state() private _inPreviewMode?: boolean;
@@ -275,7 +275,7 @@ export class NavbarCard extends LitElement {
     // Cache template evaluations
     let showBadge = false;
     if (route.badge.show !== undefined) {
-      showBadge = processTemplate<boolean>(this.hass, route.badge.show);
+      showBadge = processTemplate<boolean>(this.hass, this, route.badge.show);
     } else if (route.badge.template) {
       // TODO deprecate this
       showBadge = processBadgeTemplate(this.hass, route.badge.template);
@@ -286,12 +286,17 @@ export class NavbarCard extends LitElement {
     }
 
     const count =
-      processTemplate<number | null>(this.hass, route.badge.count) ?? null;
+      processTemplate<number | null>(this.hass, this, route.badge.count) ??
+      null;
     const hasCount = count != null;
 
     const backgroundColor =
-      processTemplate<string>(this.hass, route.badge.color) ?? 'red';
-    const textColor = processTemplate<string>(this.hass, route.badge.textColor);
+      processTemplate<string>(this.hass, this, route.badge.color) ?? 'red';
+    const textColor = processTemplate<string>(
+      this.hass,
+      this,
+      route.badge.textColor,
+    );
 
     // Only create Color object if textColor is not provided, using cached version
     const contrastingColor =
@@ -378,17 +383,17 @@ export class NavbarCard extends LitElement {
     // Cache template evaluations to avoid redundant processing
     const isActive =
       route.selected != null
-        ? processTemplate<boolean>(this.hass, route.selected)
+        ? processTemplate<boolean>(this.hass, this, route.selected)
         : window.location.pathname == route.url;
 
-    const isHidden = processTemplate<boolean>(this.hass, route.hidden);
+    const isHidden = processTemplate<boolean>(this.hass, this, route.hidden);
     if (isHidden) {
       return null;
     }
 
     // Cache label processing
     const label = this._shouldShowLabels(false)
-      ? (processTemplate<string>(this.hass, route.label) ?? ' ')
+      ? (processTemplate<string>(this.hass, this, route.label) ?? ' ')
       : null;
 
     return html`
@@ -540,6 +545,7 @@ export class NavbarCard extends LitElement {
             // Cache template evaluations
             const isHidden = processTemplate<boolean>(
               this.hass,
+              this,
               popupItem.hidden,
             );
             if (isHidden) {
@@ -547,7 +553,8 @@ export class NavbarCard extends LitElement {
             }
 
             const label = this._shouldShowLabels(true)
-              ? (processTemplate<string>(this.hass, popupItem.label) ?? ' ')
+              ? (processTemplate<string>(this.hass, this, popupItem.label) ??
+                ' ')
               : null;
 
             return html`<div
@@ -849,8 +856,16 @@ export class NavbarCard extends LitElement {
     const editModeClassname = isEditMode ? 'edit-mode' : '';
 
     // Cache hidden property evaluations
-    const isDesktopHidden = processTemplate<boolean>(this.hass, desktopHidden);
-    const isMobileHidden = processTemplate<boolean>(this.hass, mobileHidden);
+    const isDesktopHidden = processTemplate<boolean>(
+      this.hass,
+      this,
+      desktopHidden,
+    );
+    const isMobileHidden = processTemplate<boolean>(
+      this.hass,
+      this,
+      mobileHidden,
+    );
 
     // Handle hidden props
     if (

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,10 +46,10 @@ type RouteItemBase = {
   tap_action?: ExtendedActionConfig;
   hold_action?: ExtendedActionConfig;
   double_tap_action?: ExtendedActionConfig;
-  icon?: string;
-  image?: string;
-  icon_selected?: string;
-  image_selected?: string;
+  icon?: JSTemplatable<string>;
+  image?: JSTemplatable<string>;
+  icon_selected?: JSTemplatable<string>;
+  image_selected?: JSTemplatable<string>;
   label?: JSTemplatable<string>;
   badge?: {
     template?: string; // TODO deprecate

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,14 @@
 import { ActionConfig, HomeAssistant } from 'custom-card-helpers';
 
+export type NavbarCardPublicState = {
+  isDesktop: boolean;
+};
+
 export type TemplateFunction<T = unknown> = (
   states: HomeAssistant['states'],
   user: HomeAssistant['user'],
   hass: HomeAssistant,
+  navbar: NavbarCardPublicState,
 ) => T;
 
 export type RippleElement = Element & {


### PR DESCRIPTION
It's August, the sun’s out, and after taking a bit of time off to enjoy summer, I’m back with a small but useful update to `navbar-card`. This release is all about giving you more control and flexibility when using JSTemplate for customising your dashboard.

## Access Internal State in JSTemplates

You can now access the internal state of `navbar-card` from within JSTemplate functions. Currently, the only exposed parameter is `navbar.isDesktop`, which indicates whether the card is being rendered in desktop or mobile view.

This opens up lots of possibilities, like showing/hiding routes in mobile mode, switching icons, showing/hiding badges only for desktop devices... etc 

```yaml
type: custom:navbar-card
routes:
  ...
  - url: /lovelace/lights
    label: Lights
    icon: mdi:lightbulb-outline
    hidden: |
      [[[ return navbar.isDesktop; ]]]
```


## JSTemplate support for icons and images

Building on the customisation improvements, all route-level icon and image properties now support JSTemplates. That is `icon`, `icon_selected`, `image` and `image_selected`.

```yaml
type: custom:navbar-card
routes:
  - url: /lovelace/home
    icon: |
      [[[ return navbar.isDesktop ? "mdi:home" : "mdi:phone-classic" ]]]
    label: Home
...
```


#### All changes
- Add support for JSTemplates in `icon`, `icon_selected`, `image` and `image_selected`.
- Allow accessing internal navbar state from JSTemplate functions. (closes #98 )