### PR TITLE
Release/0.14.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,6 +660,40 @@ routes:
 
 </details>
 
+<details>
+<summary>Make all images display inside circles</summary>
+
+```yaml
+type: custom:navbar-card
+routes:
+  - image: |
+      [[[ 
+        return hass.states["person.jose"].attributes.entity_picture
+      ]]]
+    label: More
+    tap_action:
+      action: open-popup
+    popup:
+      - icon: mdi:cog
+        url: /config/dashboard
+      - icon: mdi:hammer
+        url: /developer-tools/yaml
+      - icon: mdi:power
+        tap_action:
+          action: call-service
+          service: homeassistant.restart
+          service_data: {}
+          confirmation:
+            text: Are you sure you want to restart Home Assistant?
+styles: |
+  .image {
+    border-radius: 16px !important;
+  }
+```
+
+</details>
+
+
 <br>
 
 ---

--- a/README.md
+++ b/README.md
@@ -147,12 +147,12 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 
 Apart from the [standard Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) (navigate, call-service, etc.), `navbar-card` supports some additional custom actions:
 
-| Action                | Description                                                | Required Parameters |
-| --------------------- | ---------------------------------------------------------- | ------------------- |
-| `open-popup`          | Opens the popup menu defined in the route                  | None                |
-| `toggle-menu`         | Opens the native HA side menu                              | None                |
-| `show-notifications`  | Opens the native HA notifications drawer                   | None                |
-| `navigate-back`       | Navigates back to the previous page in the browser history | None                |
+| Action               | Description                                                | Required Parameters |
+| -------------------- | ---------------------------------------------------------- | ------------------- |
+| `open-popup`         | Opens the popup menu defined in the route                  | None                |
+| `toggle-menu`        | Opens the native HA side menu                              | None                |
+| `show-notifications` | Opens the native HA notifications drawer                   | None                |
+| `navigate-back`      | Navigates back to the previous page in the browser history | None                |
 
 Example:
 
@@ -740,7 +740,7 @@ routes:
 </details>
 
 <details>
-<summary>Make all images display inside circles</summary>
+<summary>Route with rounded user's image</summary>
 
 ```yaml
 type: custom:navbar-card
@@ -771,7 +771,6 @@ styles: |
 ```
 
 </details>
-
 
 <br>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Navbar Card is a custom Lovelace card designed to **simplify navigation** within
 <br>
 
 [![Open your Home Assistant instance and open a repository inside the Home Assistant Community Store.](https://my.home-assistant.io/badges/hacs_repository.svg)](https://my.home-assistant.io/redirect/hacs_repository/?owner=joseluis9595&repository=lovelace-navbar-card&category=plugin)
-   
+
 </details>
 
 <details>
@@ -100,7 +100,6 @@ routes:
 ## ⚙️ Configuration
 
 <img width="400" height="120" alt="navbar-card" src="https://github.com/user-attachments/assets/346a6466-1a79-400e-9fe4-4f8472b3bee5" />
-
 
 | Name       | Type                  | Default    | Description                                                  |
 | ---------- | --------------------- | ---------- | ------------------------------------------------------------ |
@@ -174,7 +173,6 @@ Configuration to display a small badge on any of the navbar items.
 
 <img width="400" height="120" alt="navbar-card_badges" src="https://github.com/user-attachments/assets/44824ecd-9088-44c3-bab1-d900edeea614" />
 
-
 | Name        | Type                                 | Default | Description                                                     |
 | ----------- | ------------------------------------ | ------- | --------------------------------------------------------------- |
 | `show`      | boolean \| [JSTemplate](#jstemplate) | false   | Boolean template indicating whether to display the badge or not |
@@ -187,7 +185,6 @@ Configuration to display a small badge on any of the navbar items.
 For each route, a popup menu can be configured, to display a popup when clicked. This is activated using the `open-popup` action in either `tap_action` or `hold_action`.
 
 <img width="431" height="218" alt="navbar-card_popup" src="https://github.com/user-attachments/assets/520d85c7-9d73-4e73-b3c3-a4a6b2635dcb" />
-
 
 | Name          | Type                                | Default     | Description                                                                       |
 | ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
@@ -208,6 +205,8 @@ Apart from using plain javascript, you can access some predefined variables:
 
 - `states` -> Contains the global state of all entities in HomeAssistant. To get the state of a specific entity, use: `states['entity_type.your_entity'].state`.
 - `user` -> Information about the current logged user.
+- `navbar` -> Internal state of the navbar-card. Accessible fields are:
+  - `isDesktop` -> Boolean indicating whether the card is in its desktop variant or not.
 
 > **Tip**: You can use `console.log` in your JSTemplate to help debug your HomeAssistant states.
 
@@ -231,6 +230,8 @@ routes:
       ]]]
     icon: mdi:lightbulb-outline
     icon_selected: mdi:lightbulb
+    hidden: |
+      [[[ return navbar.isDesktop; ]]]
   - url: /lovelace/devices
     label: Devices
     icon: mdi:devices
@@ -349,7 +350,6 @@ You can check out some examples [here](#examples-with-custom-styles) for inspira
 Here is a breakdown of the CSS classes available for customization:
 
 - `.navbar`: Base component for the navbar.
-
   - `.navbar.desktop`: Styling for the desktop version.
   - `.navbar.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
   - `.navbar.mobile`: Styling for the mobile version.
@@ -357,23 +357,18 @@ Here is a breakdown of the CSS classes available for customization:
 - `.route`: Represents each route (or item) within the navbar.
 
 - `.button`: Background element for each icon.
-
   - `.button.active`: Applies when a route is selected.
 
 - `.icon`: Refers to the ha-icon component used for displaying icons.
-
   - `.icon.active`: Applies when a route is selected.
 
 - `.image`: Refers to the img component used for displaying route images.
-
   - `.image.active`: Applies when a route is selected.
 
 - `.label`: Text label displayed under the icons (if labels are enabled).
-
   - `.label.active`: Applies when a route is selected.
 
 - `.badge`: Small indicator or badge that appears over the icon (if configured).
-
   - `.badge.active`: Applies when a route is selected.
 
 - `.navbar-popup`: Main container for the popup.
@@ -465,7 +460,6 @@ your_theme:
 ---
 
 <br>
-
 
 ## 📚 Example Configurations
 
@@ -666,8 +660,6 @@ routes:
 
 </details>
 
-
-
 <br>
 
 ---
@@ -683,10 +675,9 @@ Need help using `navbar-card`, have ideas, or found a bug? Here's how you can re
 
 - **💬 Have questions, want to share feedback, or just chat?**<br>
   Either start [a discussion on GitHub](https://github.com/joseluis9595/lovelace-navbar-card/discussions) or join the conversation on the [Home Assistant Community Forum
-](https://community.home-assistant.io/t/navbar-card-easily-navigate-through-dashboards/832917).
+  ](https://community.home-assistant.io/t/navbar-card-easily-navigate-through-dashboards/832917).
 
 Your feedback helps make navbar-card better for everyone. Don’t hesitate to reach out!
-
 
 <br>
 
@@ -698,7 +689,6 @@ Your feedback helps make navbar-card better for everyone. Don’t hesitate to re
 
 If you enjoy using `navbar-card` and want to support its continued development, consider buying me a coffee (or a beer 🍺), or becoming a GitHub Sponsor!
 
-[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_a_Beer-fdd734?&logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/joseluis9595)  [![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-30363d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/joseluis9595)
+[![Buy Me A Coffee](https://img.shields.io/badge/Buy_Me_a_Beer-fdd734?&logo=buy-me-a-coffee&logoColor=black&style=for-the-badge)](https://www.buymeacoffee.com/joseluis9595) [![GitHub Sponsors](https://img.shields.io/badge/GitHub_Sponsors-30363d?style=for-the-badge&logo=github&logoColor=white)](https://github.com/sponsors/joseluis9595)
 
 Your support means a lot and helps keep the project alive and growing. Thank you! 🙌
-

--- a/README.md
+++ b/README.md
@@ -147,11 +147,12 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 
 Apart from the [standard Home Assistant actions](https://www.home-assistant.io/dashboards/actions/) (navigate, call-service, etc.), `navbar-card` supports some additional custom actions:
 
-| Action          | Description                                                | Required Parameters |
-| --------------- | ---------------------------------------------------------- | ------------------- |
-| `open-popup`    | Opens the popup menu defined in the route                  | None                |
-| `toggle-menu`   | Opens the native HA side menu                              | None                |
-| `navigate-back` | Navigates back to the previous page in the browser history | None                |
+| Action                | Description                                                | Required Parameters |
+| --------------------- | ---------------------------------------------------------- | ------------------- |
+| `open-popup`          | Opens the popup menu defined in the route                  | None                |
+| `toggle-menu`         | Opens the native HA side menu                              | None                |
+| `show-notifications`  | Opens the native HA notifications drawer                   | None                |
+| `navigate-back`       | Navigates back to the previous page in the browser history | None                |
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ routes:
 | `desktop`  | [Desktop](#desktop)   | -          | Options specific to desktop mode                             |
 | `mobile`   | [Mobile](#mobile)     | -          | Options specific to mobile mode                              |
 | `template` | [Template](#template) | -          | Template name                                                |
+| `layout`   | [Layout](#layout)     | -          | Layout configuration options                                 |
 | `styles`   | [Styles](#styles)     | -          | Custom CSS styles for the card                               |
 | `haptic`   | [Haptic](#haptic)     | -          | Fine tune when the haptic events should be fired in the card |
 
@@ -117,10 +118,10 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 | Name                | Type                                 | Default     | Description                                                                                                                                                |
 | ------------------- | ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`               | string                               | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                                                                           |
-| `icon`              | string \| [JSTemplate](#jstemplate) | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
-| `icon_selected`     | string \| [JSTemplate](#jstemplate) | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
-| `image`             | string \| [JSTemplate](#jstemplate) | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
-| `image_selected`    | string \| [JSTemplate](#jstemplate) | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
+| `icon`              | string \| [JSTemplate](#jstemplate)  | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
+| `icon_selected`     | string \| [JSTemplate](#jstemplate)  | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
+| `image`             | string \| [JSTemplate](#jstemplate)  | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
+| `image_selected`    | string \| [JSTemplate](#jstemplate)  | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
 | `badge`             | [Badge](#badge)                      | -           | Badge configuration                                                                                                                                        |
 | `label`             | string \| [JSTemplate](#jstemplate)  | -           | Label to be displayed under the given route if `show_labels` is true                                                                                       |
 | `tap_action`        | [tap_action](#actions)               | -           | Custom tap action configuration.                                                                                                                           |
@@ -339,6 +340,28 @@ styles: |
 
 ---
 
+### Layout
+
+Configuration options for the navbar layout and behavior.
+
+| Name           | Type                          | Default | Description                                                     |
+| -------------- | ----------------------------- | ------- | --------------------------------------------------------------- |
+| `auto_padding` | [Auto Padding](#auto-padding) | -       | Add padding to your Home Asistant dashboard to prevent overlaps |
+
+#### Auto Padding
+
+Automatically adds padding to your Home Assistnat dashboard to prevent cards from overlapping with `navbar-card`. This eliminates the need for manual CSS padding adjustments in your Home Assistant theme.
+
+| Name         | Type    | Default | Description                                                                  |
+| ------------ | ------- | ------- | ---------------------------------------------------------------------------- |
+| `enabled`    | boolean | `true`  | Whether to automatically add padding to prevent overlaps                     |
+| `desktop_px` | number  | `100`   | Padding in pixels for desktop mode (applied to left/right based on position) |
+| `mobile_px`  | number  | `80`    | Padding in pixels for mobile mode (applied to bottom)                        |
+
+> **Note**: The `desktop_px` padding is automatically applied to the appropriate side based on your navbar's `desktop.position` setting.
+
+---
+
 ### Styles
 
 Custom CSS styles can be applied to the Navbar Card to personalize its appearance and adapt it to your dashboard's design. Simply provide a CSS string targeting the relevant classes to style the navbar to your liking.
@@ -390,9 +413,30 @@ Here is a breakdown of the CSS classes available for customization:
 
 ### Padding
 
-If you're using the Navbar Card, you might notice it could collide with other cards on your dashboard. A simple way to fix this is by adding some padding to your Home Assistant views. The easiest way to do that is by using [card-mod](https://github.com/thomasloven/lovelace-card-mod) with a [custom theme](https://www.home-assistant.io/integrations/frontend/#themes).
+If you're using the Navbar Card, you might notice it could collide with other cards on your dashboard. The navbar-card now includes an [**automatic padding feature**](#auto-padding) that handles this for you, eliminating the need for manual CSS adjustments.
 
-Here's an example of how you can tweak your theme to adjust the layout for both desktop and mobile:
+#### Automatic Padding (Recommended)
+
+The navbar-card automatically adds appropriate padding to prevent overlaps:
+
+- **Desktop**: Adds padding to the left or right side based on your navbar position
+- **Mobile**: Adds bottom padding to prevent cards from overlapping the bottom navbar
+
+This feature is enabled by default, but you can customize it using the `layout.auto_padding` configuration. [More info here](#auto-padding)
+
+#### Manual Adjustement (Legacy)
+
+<details>
+<summary>If you prefer to handle padding manually or need more control, you can disable automatic padding and use CSS instead:</summary>
+
+```yaml
+type: custom:navbar-card
+layout:
+  auto_padding:
+    enabled: false # Disable automatic padding
+```
+
+Then use [card-mod](https://github.com/thomasloven/lovelace-card-mod) with a [custom theme](https://www.home-assistant.io/integrations/frontend/#themes) to add manual padding:
 
 ```yaml
 your_theme:
@@ -417,6 +461,10 @@ your_theme:
         }
       }
 ```
+
+</details>
+
+---
 
 ### Hiding native tabs
 
@@ -468,6 +516,11 @@ your_theme:
 
 ```yaml
 type: custom:navbar-card
+layout:
+  auto_padding:
+    enabled: true
+    desktop_px: 100
+    mobile_px: 80
 desktop:
   position: left
   min_width: 768
@@ -609,6 +662,31 @@ styles: |
 ```
 
 ![bottom_padding](https://github.com/user-attachments/assets/b08cab6b-c978-48af-8fb3-57d2d0599925)
+
+</details>
+
+<details>
+<summary>Custom auto-padding configuration</summary>
+
+```yaml
+type: custom:navbar-card
+layout:
+  auto_padding:
+    enabled: true
+    desktop_px: 150 # Extra wide padding for desktop
+    mobile_px: 120 # Extra tall padding for mobile
+desktop:
+  position: right # Padding will be applied to the right
+  show_labels: true
+routes:
+  - url: /lovelace/home
+    label: Home
+    icon: mdi:home-outline
+    icon_selected: mdi:home-assistant
+  - url: /lovelace/devices
+    label: Devices
+    icon: mdi:devices
+```
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -117,10 +117,10 @@ Routes represents an array of clickable icons that redirects to a given path. Ea
 | Name                | Type                                 | Default     | Description                                                                                                                                                |
 | ------------------- | ------------------------------------ | ----------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `url`               | string                               | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                                                                                           |
-| `icon`              | string                               | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
-| `icon_selected`     | string                               | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
-| `image`             | string                               | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
-| `image_selected`    | string                               | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
+| `icon`              | string \| [JSTemplate](#jstemplate) | -           | Material icon to display as this entry icon. Either `icon` or `image` is required.                                                                         |
+| `icon_selected`     | string \| [JSTemplate](#jstemplate) | -           | Icon to be displayed when `url` matches the current browser URL                                                                                            |
+| `image`             | string \| [JSTemplate](#jstemplate) | -           | URL of an image to display as this entry icon. Either `icon` or `image` is required.                                                                       |
+| `image_selected`    | string \| [JSTemplate](#jstemplate) | -           | Image to be displayed when `url` matches the current browser URL                                                                                           |
 | `badge`             | [Badge](#badge)                      | -           | Badge configuration                                                                                                                                        |
 | `label`             | string \| [JSTemplate](#jstemplate)  | -           | Label to be displayed under the given route if `show_labels` is true                                                                                       |
 | `tap_action`        | [tap_action](#actions)               | -           | Custom tap action configuration.                                                                                                                           |
@@ -189,7 +189,7 @@ For each route, a popup menu can be configured, to display a popup when clicked.
 | Name          | Type                                | Default     | Description                                                                       |
 | ------------- | ----------------------------------- | ----------- | --------------------------------------------------------------------------------- |
 | `url`         | string                              | `Required*` | The path to a Lovelace view. Ignored if `tap_action` is defined.                  |
-| `icon`        | string                              | `Required`  | Material icon to display as this entry icon                                       |
+| `icon`        | string \| [JSTemplate](#jstemplate) | `Required`  | Material icon to display as this entry icon                                       |
 | `badge`       | [Badge](#badge)                     | -           | Badge configuration                                                               |
 | `label`       | string \| [JSTemplate](#jstemplate) | -           | Label to be displayed under the given route if `show_labels` is true              |
 | `tap_action`  | [tap_action](#actions)              | -           | Custom tap action configuration, including 'open-popup' to display a popup menu.  |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -120,17 +120,18 @@ export const forceDashboardPadding = (options?: {
   const mobilePaddingPx =
     options?.auto_padding?.mobile_px ??
     DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.mobile_px;
-  const mobilePadding = `padding-bottom: ${mobilePaddingPx}px !important;`;
 
-  if (mobilePadding) {
-    cssText += `
-        @media (max-width: ${mobileMaxWidth}px) {
-          :not(.edit-mode) > hui-view:after {
-            ${mobilePadding}
-          }
+  cssText += `
+      @media (max-width: ${mobileMaxWidth}px) {
+        :not(.edit-mode) > hui-view:after {
+          content: "";
+          display: block;
+          height: ${mobilePaddingPx}px;
+          width: 100%;
+          background-color: transparent; 
         }
-      `;
-  }
+      }
+    `;
 
   // Append styles to hui-root
   if (!styleEl) {

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -1,4 +1,9 @@
-import { NavbarCardConfig, RippleElement } from './types';
+import {
+  AutoPaddingConfig,
+  DEFAULT_NAVBAR_CONFIG,
+  NavbarCardConfig,
+  RippleElement,
+} from './types';
 
 /**
  * Get a list of user defined navbar-card templates
@@ -35,4 +40,105 @@ export const forceResetRipple = (target: HTMLElement) => {
       ripple.pressed = false;
     }, 10);
   });
+};
+
+/**
+ * Find the hui-root element in the DOM.
+ *
+ * @returns The hui-root element or null if not found.
+ */
+const findHuiRoot = () => {
+  return window.document
+    .querySelector('home-assistant')
+    ?.shadowRoot?.querySelector('home-assistant-main')
+    ?.shadowRoot?.querySelector('ha-panel-lovelace')
+    ?.shadowRoot?.querySelector('hui-root');
+};
+
+/**
+ * Manually inject styles into the hui-root element to force dashboard padding.
+ * This prevents overlaps with other cards in the dashboard.
+ */
+export const forceDashboardPadding = (options?: {
+  desktop: NavbarCardConfig['desktop'];
+  mobile: NavbarCardConfig['mobile'];
+  auto_padding: AutoPaddingConfig;
+}) => {
+  const autoPaddingEnabled =
+    options?.auto_padding?.enabled ??
+    DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.enabled;
+
+  // Find hui-root element
+  const huiRoot = findHuiRoot();
+  if (!huiRoot?.shadowRoot) {
+    console.warn(
+      '[navbar-card] Could not find hui-root. Custom padding styles will not be applied.',
+    );
+    return;
+  }
+
+  // Find existing style element
+  const styleId = 'navbar-card-forced-padding-styles';
+  let styleEl = huiRoot.shadowRoot.querySelector<HTMLStyleElement>(
+    `#${styleId}`,
+  );
+
+  // Remove styles if auto padding is disabled
+  if (!autoPaddingEnabled) {
+    if (styleEl) {
+      styleEl.remove();
+    }
+    return;
+  }
+
+  // Initialize variables
+  const desktopMinWidth = options?.desktop?.min_width ?? 768;
+  const mobileMaxWidth = desktopMinWidth - 1;
+  let cssText = '';
+
+  // Desktop padding
+  const desktopPaddingPx =
+    options?.auto_padding?.desktop_px ??
+    DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.desktop_px;
+  const desktopPadding =
+    options?.desktop?.position === 'left'
+      ? `padding-left: ${desktopPaddingPx}px !important;`
+      : options?.desktop?.position === 'right'
+        ? `padding-right: ${desktopPaddingPx}px !important;`
+        : undefined;
+  if (desktopPadding) {
+    cssText += `
+        @media (min-width: ${desktopMinWidth}px) {
+          :not(.edit-mode) > #view {
+            ${desktopPadding}
+          }
+        }
+      `;
+  }
+
+  // Mobile padding
+  const mobilePaddingPx =
+    options?.auto_padding?.mobile_px ??
+    DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.mobile_px;
+  const mobilePadding = `padding-bottom: ${mobilePaddingPx}px !important;`;
+
+  if (mobilePadding) {
+    cssText += `
+        @media (max-width: ${mobileMaxWidth}px) {
+          :not(.edit-mode) > hui-view:after {
+            ${mobilePadding}
+          }
+        }
+      `;
+  }
+
+  // Append styles to hui-root
+  if (!styleEl) {
+    styleEl = document.createElement('style');
+    styleEl.id = styleId;
+    styleEl.textContent = cssText;
+    huiRoot.shadowRoot.appendChild(styleEl);
+  } else {
+    styleEl.textContent = cssText;
+  }
 };

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -10,6 +10,7 @@ import { customElement, state } from 'lit/decorators.js';
 import { version } from '../package.json';
 import { HomeAssistant, navigate } from 'custom-card-helpers';
 import {
+  DEFAULT_NAVBAR_CONFIG,
   DesktopPosition,
   NavbarCardConfig,
   PopupItem,
@@ -23,7 +24,11 @@ import {
   processBadgeTemplate,
   processTemplate,
 } from './utils';
-import { forceResetRipple, getNavbarTemplates } from './dom-utils';
+import {
+  forceDashboardPadding,
+  forceResetRipple,
+  getNavbarTemplates,
+} from './dom-utils';
 import { getDefaultStyles } from './styles';
 import { Color } from './color';
 
@@ -116,6 +121,14 @@ export class NavbarCard extends LitElement {
   }
 
   setConfig(config) {
+    forceDashboardPadding({
+      desktop: config.desktop ?? DEFAULT_NAVBAR_CONFIG.desktop,
+      mobile: config.mobile ?? DEFAULT_NAVBAR_CONFIG.mobile,
+      auto_padding:
+        config.layout?.auto_padding ??
+        DEFAULT_NAVBAR_CONFIG.layout?.auto_padding,
+    });
+
     // Check for template configuration
     if (config?.template) {
       // Get templates from the DOM

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -252,18 +252,27 @@ export class NavbarCard extends LitElement {
   /* Subcomponents */
   /**********************************************************************/
   private _getRouteIcon(route: RouteItem | PopupItem, isActive: boolean) {
-    return route.image
+    const icon = processTemplate<string>(this.hass, this, route.icon);
+    const image = processTemplate<string>(this.hass, this, route.image);
+    const iconSelected = processTemplate<string>(
+      this.hass,
+      this,
+      route.icon_selected,
+    );
+    const imageSelected = processTemplate<string>(
+      this.hass,
+      this,
+      route.image_selected,
+    );
+
+    return image
       ? html`<img
           class="image ${isActive ? 'active' : ''}"
-          src="${isActive && route.image_selected
-            ? route.image_selected
-            : route.image}"
+          src="${isActive && imageSelected ? imageSelected : image}"
           alt="${route.label || ''}" />`
       : html`<ha-icon
           class="icon ${isActive ? 'active' : ''}"
-          icon="${isActive && route.icon_selected
-            ? route.icon_selected
-            : route.icon}"></ha-icon>`;
+          icon="${isActive && iconSelected ? iconSelected : icon}"></ha-icon>`;
   }
 
   private _renderBadge(route: RouteItem | PopupItem, isRouteActive: boolean) {
@@ -876,7 +885,6 @@ export class NavbarCard extends LitElement {
       return html``;
     }
 
-    // TODO use HA ripple effect for icon button
     return html`
       <ha-card
         class="navbar ${editModeClassname} ${deviceModeClassName} ${desktopPositionClassname}">

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -51,7 +51,7 @@ const HOLD_ACTION_DELAY = 500;
 export class NavbarCard extends LitElement {
   @state() protected hass!: HomeAssistant;
   @state() private _config?: NavbarCardConfig;
-  @state() private _isDesktop?: boolean;
+  @state() _isDesktop?: boolean;
   @state() private _inEditDashboardMode?: boolean;
   @state() private _inEditCardMode?: boolean;
   @state() private _inPreviewMode?: boolean;
@@ -275,7 +275,7 @@ export class NavbarCard extends LitElement {
     // Cache template evaluations
     let showBadge = false;
     if (route.badge.show !== undefined) {
-      showBadge = processTemplate<boolean>(this.hass, route.badge.show);
+      showBadge = processTemplate<boolean>(this.hass, this, route.badge.show);
     } else if (route.badge.template) {
       // TODO deprecate this
       showBadge = processBadgeTemplate(this.hass, route.badge.template);
@@ -286,12 +286,17 @@ export class NavbarCard extends LitElement {
     }
 
     const count =
-      processTemplate<number | null>(this.hass, route.badge.count) ?? null;
+      processTemplate<number | null>(this.hass, this, route.badge.count) ??
+      null;
     const hasCount = count != null;
 
     const backgroundColor =
-      processTemplate<string>(this.hass, route.badge.color) ?? 'red';
-    const textColor = processTemplate<string>(this.hass, route.badge.textColor);
+      processTemplate<string>(this.hass, this, route.badge.color) ?? 'red';
+    const textColor = processTemplate<string>(
+      this.hass,
+      this,
+      route.badge.textColor,
+    );
 
     // Only create Color object if textColor is not provided, using cached version
     const contrastingColor =
@@ -378,17 +383,17 @@ export class NavbarCard extends LitElement {
     // Cache template evaluations to avoid redundant processing
     const isActive =
       route.selected != null
-        ? processTemplate<boolean>(this.hass, route.selected)
+        ? processTemplate<boolean>(this.hass, this, route.selected)
         : window.location.pathname == route.url;
 
-    const isHidden = processTemplate<boolean>(this.hass, route.hidden);
+    const isHidden = processTemplate<boolean>(this.hass, this, route.hidden);
     if (isHidden) {
       return null;
     }
 
     // Cache label processing
     const label = this._shouldShowLabels(false)
-      ? (processTemplate<string>(this.hass, route.label) ?? ' ')
+      ? (processTemplate<string>(this.hass, this, route.label) ?? ' ')
       : null;
 
     return html`
@@ -540,6 +545,7 @@ export class NavbarCard extends LitElement {
             // Cache template evaluations
             const isHidden = processTemplate<boolean>(
               this.hass,
+              this,
               popupItem.hidden,
             );
             if (isHidden) {
@@ -547,7 +553,8 @@ export class NavbarCard extends LitElement {
             }
 
             const label = this._shouldShowLabels(true)
-              ? (processTemplate<string>(this.hass, popupItem.label) ?? ' ')
+              ? (processTemplate<string>(this.hass, this, popupItem.label) ??
+                ' ')
               : null;
 
             return html`<div
@@ -849,8 +856,16 @@ export class NavbarCard extends LitElement {
     const editModeClassname = isEditMode ? 'edit-mode' : '';
 
     // Cache hidden property evaluations
-    const isDesktopHidden = processTemplate<boolean>(this.hass, desktopHidden);
-    const isMobileHidden = processTemplate<boolean>(this.hass, mobileHidden);
+    const isDesktopHidden = processTemplate<boolean>(
+      this.hass,
+      this,
+      desktopHidden,
+    );
+    const isMobileHidden = processTemplate<boolean>(
+      this.hass,
+      this,
+      mobileHidden,
+    );
 
     // Handle hidden props
     if (

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -819,6 +819,14 @@ export class NavbarCard extends LitElement {
         hapticFeedback();
       }
       fireDOMEvent(this, 'hass-toggle-menu', { bubbles: true, composed: true });
+    } else if (action?.action === 'show-notifications') {
+      if (this._shouldTriggerHaptic(actionType)) {
+        hapticFeedback();
+      }
+      fireDOMEvent(this, 'hass-show-notifications', {
+        bubbles: true,
+        composed: true,
+      });
     } else if (action?.action === 'navigate-back') {
       if (this._shouldTriggerHaptic(actionType, true)) {
         hapticFeedback();

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,10 +46,10 @@ type RouteItemBase = {
   tap_action?: ExtendedActionConfig;
   hold_action?: ExtendedActionConfig;
   double_tap_action?: ExtendedActionConfig;
-  icon?: string;
-  image?: string;
-  icon_selected?: string;
-  image_selected?: string;
+  icon?: JSTemplatable<string>;
+  image?: JSTemplatable<string>;
+  icon_selected?: JSTemplatable<string>;
+  image_selected?: JSTemplatable<string>;
   label?: JSTemplatable<string>;
   badge?: {
     template?: string; // TODO deprecate

--- a/src/types.ts
+++ b/src/types.ts
@@ -30,12 +30,16 @@ type PopupActionConfig = {
 type NavigateBackActionConfig = {
   action: 'navigate-back';
 };
+type ShowNotificationsActionConfig = {
+  action: 'show-notifications';
+};
 
 // Extend ActionConfig to include our custom popup action
 export type ExtendedActionConfig =
   | ActionConfig
   | PopupActionConfig
-  | NavigateBackActionConfig;
+  | NavigateBackActionConfig
+  | ShowNotificationsActionConfig;
 
 type JSTemplate = string;
 type JSTemplatable<T> = JSTemplate | T;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,14 @@
 import { ActionConfig, HomeAssistant } from 'custom-card-helpers';
 
+export type NavbarCardPublicState = {
+  isDesktop: boolean;
+};
+
 export type TemplateFunction<T = unknown> = (
   states: HomeAssistant['states'],
   user: HomeAssistant['user'],
   hass: HomeAssistant,
+  navbar: NavbarCardPublicState,
 ) => T;
 
 export type RippleElement = Element & {

--- a/src/types.ts
+++ b/src/types.ts
@@ -82,10 +82,19 @@ export type HapticConfig = {
   double_tap_action?: boolean;
 };
 
+export type AutoPaddingConfig = {
+  enabled: boolean;
+  desktop_px?: number;
+  mobile_px?: number;
+};
+
 // Main card configuration
 export type NavbarCardConfig = {
   routes: RouteItem[];
   template?: string;
+  layout?: {
+    auto_padding?: AutoPaddingConfig;
+  };
   desktop?: {
     show_labels?: LabelVisibilityConfig;
     min_width?: number;
@@ -98,4 +107,24 @@ export type NavbarCardConfig = {
   };
   styles?: string;
   haptic?: boolean | HapticConfig;
+};
+
+export const DEFAULT_NAVBAR_CONFIG: NavbarCardConfig = {
+  routes: [],
+  template: undefined,
+  layout: {
+    auto_padding: {
+      enabled: true,
+      desktop_px: 100,
+      mobile_px: 80,
+    },
+  },
+  desktop: {
+    show_labels: false,
+    min_width: 768,
+    position: DesktopPosition.left,
+  },
+  mobile: {
+    show_labels: false,
+  },
 };


### PR DESCRIPTION
## Auto adjust Dashboard paddings

> [!CAUTION]
> **Breaking change!**
> Users with custom themes configured to add padding to your dashboard, might need to either disable this new functionality, or remove their custom css.

There's a highly requested new feature, which is now enabled by default—**Auto padding for your home assistant dashboard** when using `navbar-card`.

What does this mean? No more custom css using home assistant themes and card-mod. Simply add navbar-card to your dashboard, and overlaps with other cards will automatically be prevented.

This new behaviour, as previously stated, is enabled by default. So any of you currently using custom css styles to add padding to your dashboard, might need to either remove it, or disable the new `auto_padding` feature:

```yaml
type: custom:navbar-card
layout:
  auto_padding:
    enabled: false
```

You can also configure the amount of padding added, either for desktop or mobile, by changing the `desktop_px` or `mobile_px` variables:

```yaml
type: custom:navbar-card
layout:
  auto_padding:
    enabled: true
    desktop_px: 100
    mobile_px: 80
```


## Open notifications tray

I've also included in this release, a new custom action `show_notiffications`, to open the native Home Assistant's notification tray. Some of you are completely disabling the original tabs navigation of your dashboards, and this new action may come handy.

```yaml
type: custom:navbar-card
routes:
  - icon: mdi:devices
    url: /lovelace/devices
    label: Devices
    hold_action:
      action: show-notifications
```

<br/>

---

#### All changes

- New `auto_padding` feature enabled by default. (closes #104 )
- New `show_notifications` action. (closes #109)
- Added new examples to README (thanks @coolssor )