### PR TITLE
Extend popup item backgrounds to include labels

### DIFF
--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -264,7 +264,7 @@ export class NavbarCard extends LitElement {
   /**********************************************************************/
   /* Subcomponents */
   /**********************************************************************/
-  private _getRouteIcon(route: RouteItem | PopupItem, isActive: boolean) {
+  private _getRouteIcon(route: RouteItem | PopupItem, isActive: boolean, isPopup: boolean) {
     const icon = processTemplate<string>(this.hass, this, route.icon);
     const image = processTemplate<string>(this.hass, this, route.image);
     const iconSelected = processTemplate<string>(
@@ -284,7 +284,7 @@ export class NavbarCard extends LitElement {
           src="${isActive && imageSelected ? imageSelected : image}"
           alt="${route.label || ''}" />`
       : html`<ha-icon
-          class="icon ${isActive ? 'active' : ''}"
+          class="icon ${isActive ? 'active' : ''} ${isPopup ? 'popup' : ''}"
           icon="${isActive && iconSelected ? iconSelected : icon}"></ha-icon>`;
   }
 
@@ -430,7 +430,7 @@ export class NavbarCard extends LitElement {
         @pointercancel=${(e: PointerEvent) =>
           this._handlePointerMove(e, route)}>
         <div class="button ${isActive ? 'active' : ''}">
-          ${this._getRouteIcon(route, isActive)}
+          ${this._getRouteIcon(route, isActive, false)}
           <ha-ripple></ha-ripple>
         </div>
 
@@ -589,7 +589,7 @@ export class NavbarCard extends LitElement {
               @click=${(e: MouseEvent) =>
                 this._handlePointerUp(e as PointerEvent, popupItem, true)}>
               <div class="button">
-                ${this._getRouteIcon(popupItem, false)}
+                ${this._getRouteIcon(popupItem, false, true)}
                 ${label ? html`<div class="label">${label}</div>` : html``}
                 <md-ripple></md-ripple>
               </div>

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -590,9 +590,9 @@ export class NavbarCard extends LitElement {
                 this._handlePointerUp(e as PointerEvent, popupItem, true)}>
               <div class="button">
                 ${this._getRouteIcon(popupItem, false)}
+                ${label ? html`<div class="label">${label}</div>` : html``}
                 <md-ripple></md-ripple>
               </div>
-              ${label ? html`<div class="label">${label}</div>` : html``}
               ${this._renderBadge(popupItem, false)}
             </div>`;
           })

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -130,7 +130,7 @@ const ROUTE_STYLES = css`
     --mdc-icon-size: var(--navbar-route-icon-size);
   }
 
-  .icon.sidebar {
+  .icon.popup {
     margin-right: 4px;
   }
 

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -112,7 +112,7 @@ const ROUTE_STYLES = css`
     width: 100%;
     border-radius: 16px;
     display: flex;
-    flex-direction: column;
+    flex-direction: row;
     align-items: center;
     justify-content: center;
   }
@@ -128,6 +128,10 @@ const ROUTE_STYLES = css`
   /* Icon and Image styling */
   .icon {
     --mdc-icon-size: var(--navbar-route-icon-size);
+  }
+
+  .icon.sidebar {
+    margin-right: 4px;
   }
 
   .image {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -112,7 +112,7 @@ const ROUTE_STYLES = css`
     width: 100%;
     border-radius: 16px;
     display: flex;
-    flex-direction: row;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
   }
@@ -315,8 +315,11 @@ const POPUP_STYLES = css`
   }
 
   .popup-item .button {
-    width: 50px;
+    width: 100%;
     height: 50px;
+    padding-left: 8px;
+    padding-right: 8px;
+    flex-direction: row;
     background: var(--navbar-background-color);
     box-shadow: var(--navbar-box-shadow-desktop);
   }

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -214,6 +214,7 @@ const POPUP_STYLES = css`
     position: fixed;
     opacity: 0;
     padding: 6px;
+    padding-left: 0px;
     gap: 10px;
     z-index: var(--navbar-popup-index);
 


### PR DESCRIPTION
For accessibility of popup item labels, the background can be extended across.

<img width="239" height="386" alt="image" src="https://github.com/user-attachments/assets/85646e04-3739-47c4-9d92-b12a82aa482b" />

The varying widths isn't the nicest but it's the best I can come up with.
