### PR TITLE
Release/0.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,16 @@ routes:
 
 <img width="400" height="120" alt="navbar-card" src="https://github.com/user-attachments/assets/346a6466-1a79-400e-9fe4-4f8472b3bee5" />
 
-| Name       | Type                  | Default    | Description                                                  |
-| ---------- | --------------------- | ---------- | ------------------------------------------------------------ |
-| `routes`   | [Routes](#routes)     | `Required` | Defines the array of routes to be shown in the navbar        |
-| `desktop`  | [Desktop](#desktop)   | -          | Options specific to desktop mode                             |
-| `mobile`   | [Mobile](#mobile)     | -          | Options specific to mobile mode                              |
-| `template` | [Template](#template) | -          | Template name                                                |
-| `layout`   | [Layout](#layout)     | -          | Layout configuration options                                 |
-| `styles`   | [Styles](#styles)     | -          | Custom CSS styles for the card                               |
-| `haptic`   | [Haptic](#haptic)     | -          | Fine tune when the haptic events should be fired in the card |
+| Name           | Type                          | Default    | Description                                                                                             |
+| -------------- | ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------- |
+| `routes`       | [Routes](#routes)             | `Required` | Defines the array of routes to be shown in the navbar                                                   |
+| `desktop`      | [Desktop](#desktop)           | -          | Options specific to desktop mode                                                                        |
+| `mobile`       | [Mobile](#mobile)             | -          | Options specific to mobile mode                                                                         |
+| `template`     | [Template](#template)         | -          | Template name                                                                                           |
+| `layout`       | [Layout](#layout)             | -          | Layout configuration options                                                                            |
+| `styles`       | [Styles](#styles)             | -          | Custom CSS styles for the card                                                                          |
+| `haptic`       | [Haptic](#haptic)             | -          | Fine tune when the haptic events should be fired in the card                                            |
+| `media_player` | [Media player](#media-player) | -          | `[BETA]` Automatically display a media_player card on top of navbar-card. Only enabled for mobile mode. |
 
 ### Routes
 
@@ -276,7 +277,6 @@ Specific configuration for mobile mode.
 
 <img width="785" height="108" alt="navbar-card_mobile" src="https://github.com/user-attachments/assets/b8134d65-d237-412a-9c0b-dfc9c009de46" />
 
-
 | Name          | Type                                     | Default  | Description                                                                                                             |
 | ------------- | ---------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
 | `show_labels` | boolean \| `popup_only` \| `routes_only` | `false`  | Whether or not to display labels under each route                                                                       |
@@ -295,6 +295,18 @@ Controls when haptic feedback is triggered. You can either use a boolean to enab
 | `tap_action`        | boolean | `false` | Trigger on tap actions                |
 | `hold_action`       | boolean | `false` | Trigger on hold actions               |
 | `double_tap_action` | boolean | `false` | Trigger on double tap actions         |
+
+---
+
+### Media player
+
+When enabled, this configuration displays a `media_player` widget above the `navbar-card`. Currently, it is shown only in mobile mode and only when the `media_player` state is `paused` or `playing`.
+
+<img width="445" height="166" alt="navbar-card_media-player" src="https://github.com/user-attachments/assets/b8898268-e232-4759-b35c-23a1afd43e7a" />
+
+| Option   | Type   | Default | Description                   |
+| -------- | ------ | ------- | ----------------------------- |
+| `entity` | string | -       | Entity ID of the media_player |
 
 ---
 
@@ -387,11 +399,17 @@ You can check out some examples [here](#examples-with-custom-styles) for inspira
 
 Here is a breakdown of the CSS classes available for customization:
 
-- `.navbar`: Base component for the navbar.
+- `.navbar`: Main wrapper of navbar-card and its widgets.
   - `.navbar.desktop`: Styling for the desktop version.
   - `.navbar.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
   - `.navbar.mobile`: Styling for the mobile version.
   - `.navbar.mobile.floating`: Styling for the mobile version when using `floating` mode.
+
+- `.navbar-card`: The navbar-card itself (`ha-card` component).
+  - `.navbar-card.desktop`: Styling for the desktop version.
+  - `.navbar-card.desktop.[top | bottom | left | right]`: Specific styles for different positions of the navbar.
+  - `.navbar-card.mobile`: Styling for the mobile version.
+  - `.navbar-card.mobile.floating`: Styling for the mobile version when using `floating` mode.
 
 - `.route`: Represents each route (or item) within the navbar.
 
@@ -418,6 +436,35 @@ Here is a breakdown of the CSS classes available for customization:
   - `.popup-item.label-[top | bottom | left | right]`: Specific styles for different positions of the label.
   - `.popup-item .label`: Styles applied to the label of each popup item.
   - `.popup-item .button`: Button for each popup item, containing just the icon.
+
+- `.media-player`: Styles applied to the media-player card
+- `.media-player-bg`: Background of the media-player. This contains the image of the current media playing, blurred and with very low opacity
+- `.media-player-image`: Image container of the current song
+- `.media-player-info`: Container for the title and artist
+- `.media-player-title`: Container for the title
+- `.media-player-artist`: Container for the artist
+- `.media-player-button`: Class applied to all buttons in the media_player card
+- `.media-player-button-play-pause`: Play pause button
+- `.media-player-progress-bar`: Container for the progress bar of the current playing media
+- `.media-player-progress-bar-fill`: Filled section of the progress bar
+
+#### CSS variables
+
+The `.navbar` component relies on a set of CSS variables to manage its styling. You can customize its appearance by overriding the following variables:
+
+| Name                                  | Default value                        | Uses                                                              |
+| ------------------------------------- | ------------------------------------ | ----------------------------------------------------------------- |
+| `--navbar-primary-color`              | var(--primary-color)                 | Accent color used for navbar-card                                 |
+| `--navbar-border-radius`              | var(--ha-card-border-radius, 12px)   | Border radius applied to all `ha-card` elements inside `.navbar`  |
+| `--navbar-background-color`           | var(--card-background-color)         | Background color used for all `ha-card` elements inside `.navbar` |
+| `--navbar-route-icon-size`            | 24px                                 | Size in pixels for each `.icon` element                           |
+| `--navbar-route-image-size`           | 32px                                 | Size in pixels for each `.image` element                          |
+| `--navbar-box-shadow`                 | 0px -1px 4px 0px rgba(0, 0, 0, 0.14) | Box shadow used in mobile docked layout                           |
+| `--navbar-box-shadow-mobile-floating` | var(--material-shadow-elevation-2dp) | Box shadow used in mobile floating mode                           |
+| `--navbar-box-shadow-desktop`         | var(--material-shadow-elevation-2dp) | Box shadow used in desktop mode                                   |
+| `--navbar-z-index`                    | 3                                    | Default z-index for navbar-card                                   |
+| `--navbar-popup-backdrop-z-index`     | 900                                  | z-index used for the `.navbar-popup-backdrop` element             |
+| `--navbar-popup-z-index`              | 901                                  | z-index used for the `.navbar-popup` element                      |
 
 <br>
 
@@ -624,7 +671,7 @@ routes:
     label: Devices
     icon: mdi:devices
 styles: |
-  .navbar {
+  .navbar-card {
     background: #000000;
   }
 ```
@@ -647,7 +694,7 @@ routes:
     label: Devices
     icon: mdi:devices
 styles: |
-  .navbar.desktop{
+  .navbar-card.desktop {
     border-radius: 0px;
   }
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "0.16.0",
+  "version": "0.17.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/__tests__/navbar-card.test.ts
+++ b/src/__tests__/navbar-card.test.ts
@@ -70,8 +70,7 @@ describe('NavbarCard', () => {
     await element.updateComplete;
 
     // Set up the element
-    // @ts-expect-error - Private property access for testing
-    element.hass = hass;
+    element._hass = hass;
     element.setConfig(DEFAULT_CONFIG);
     await element.updateComplete;
   });
@@ -140,8 +139,7 @@ describe('NavbarCard', () => {
       window.dispatchEvent(new Event('resize'));
       await element.updateComplete;
 
-      // @ts-expect-error - Private property access for testing
-      expect(element._isDesktop).toBe(true);
+      expect(element.isDesktop).toBe(true);
     });
 
     it('detects mobile mode correctly', async () => {
@@ -156,8 +154,7 @@ describe('NavbarCard', () => {
       window.dispatchEvent(new Event('resize'));
       await element.updateComplete;
 
-      // @ts-expect-error - Private property access for testing
-      expect(element._isDesktop).toBe(false);
+      expect(element.isDesktop).toBe(false);
     });
   });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -79,15 +79,23 @@ export type HapticConfig = {
   double_tap_action?: boolean;
 };
 
+// Auto padding configuration
 export type AutoPaddingConfig = {
   enabled: boolean;
   desktop_px?: number;
   mobile_px?: number;
+  media_player_px?: number;
+};
+
+// Media player configuration
+type MediaPlayerConfig = {
+  entity: string;
 };
 
 // Main card configuration
 export type NavbarCardConfig = {
   routes: RouteItem[];
+  media_player?: MediaPlayerConfig;
   template?: string;
   layout?: {
     auto_padding?: AutoPaddingConfig;
@@ -115,6 +123,7 @@ export const DEFAULT_NAVBAR_CONFIG: NavbarCardConfig = {
       enabled: true,
       desktop_px: 100,
       mobile_px: 80,
+      media_player_px: 100,
     },
   },
   desktop: {
@@ -126,4 +135,50 @@ export const DEFAULT_NAVBAR_CONFIG: NavbarCardConfig = {
     show_labels: false,
     mode: 'docked',
   },
+};
+
+export const STUB_CONFIG: NavbarCardConfig = {
+  routes: [
+    { url: window.location.pathname, icon: 'mdi:home', label: 'Home' },
+    {
+      url: `${window.location.pathname}/devices`,
+      icon: 'mdi:devices',
+      label: 'Devices',
+      hold_action: {
+        action: 'navigate',
+        navigation_path: '/config/devices/dashboard',
+      },
+    },
+    {
+      url: '/config/automation/dashboard',
+      icon: 'mdi:creation',
+      label: 'Automations',
+    },
+    { url: '/config/dashboard', icon: 'mdi:cog', label: 'Settings' },
+    {
+      icon: 'mdi:dots-horizontal',
+      label: 'More',
+      tap_action: {
+        action: 'open-popup',
+      },
+      popup: [
+        { icon: 'mdi:cog', url: '/config/dashboard' },
+        {
+          icon: 'mdi:hammer',
+          url: '/developer-tools/yaml',
+        },
+        {
+          icon: 'mdi:power',
+          tap_action: {
+            action: 'call-service',
+            service: 'homeassistant.restart',
+            service_data: {},
+            confirmation: {
+              text: 'Are you sure you want to restart Home Assistant?',
+            },
+          },
+        },
+      ],
+    },
+  ],
 };

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -5,6 +5,8 @@ import {
 } from './config';
 import { RippleElement } from './types';
 
+const DASHBOARD_PADDING_STYLE_ID = 'navbar-card-forced-padding-styles';
+
 /**
  * Get a list of user defined navbar-card templates
  */
@@ -66,13 +68,28 @@ export const forceOpenEditMode = () => {
 };
 
 /**
+ * Remove the dashboard padding styles from the hui-root element.
+ */
+export const removeDashboardPadding = () => {
+  const huiRoot = findHuiRoot();
+  if (!huiRoot?.shadowRoot) return;
+  const styleEl = huiRoot.shadowRoot.querySelector<HTMLStyleElement>(
+    `#${DASHBOARD_PADDING_STYLE_ID}`,
+  );
+  if (styleEl) {
+    styleEl.remove();
+  }
+};
+
+/**
  * Manually inject styles into the hui-root element to force dashboard padding.
  * This prevents overlaps with other cards in the dashboard.
  */
 export const forceDashboardPadding = (options?: {
   desktop: NavbarCardConfig['desktop'];
   mobile: NavbarCardConfig['mobile'];
-  auto_padding: AutoPaddingConfig;
+  auto_padding?: AutoPaddingConfig;
+  show_media_player: boolean;
 }) => {
   const autoPaddingEnabled =
     options?.auto_padding?.enabled ??
@@ -88,9 +105,8 @@ export const forceDashboardPadding = (options?: {
   }
 
   // Find existing style element
-  const styleId = 'navbar-card-forced-padding-styles';
   let styleEl = huiRoot.shadowRoot.querySelector<HTMLStyleElement>(
-    `#${styleId}`,
+    `#${DASHBOARD_PADDING_STYLE_ID}`,
   );
 
   // Remove styles if auto padding is disabled
@@ -142,11 +158,18 @@ export const forceDashboardPadding = (options?: {
   }
 
   // Mobile padding
-  const mobilePaddingPx =
+  let mobilePaddingPx =
     options?.auto_padding?.mobile_px ??
     DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.mobile_px ??
     0;
-
+  // Add media player padding if enabled
+  if (options?.show_media_player) {
+    mobilePaddingPx +=
+      options?.auto_padding?.media_player_px ??
+      DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.media_player_px ??
+      0;
+  }
+  // Add padding to the DOM
   if (mobilePaddingPx > 0) {
     cssText += `
       @media (max-width: ${mobileMaxWidth}px) {
@@ -164,7 +187,7 @@ export const forceDashboardPadding = (options?: {
   // Append styles to hui-root
   if (!styleEl) {
     styleEl = document.createElement('style');
-    styleEl.id = styleId;
+    styleEl.id = DASHBOARD_PADDING_STYLE_ID;
     styleEl.textContent = cssText;
     huiRoot.shadowRoot.appendChild(styleEl);
   } else {

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -9,99 +9,215 @@ const HOST_STYLES = css`
     --navbar-primary-color: var(--primary-color);
     --navbar-box-shadow: 0px -1px 4px 0px rgba(0, 0, 0, 0.14);
     --navbar-box-shadow-desktop: var(--material-shadow-elevation-2dp);
-    --navbar-box-shadow-mobile: var(--material-shadow-elevation-2dp);
+    --navbar-box-shadow-mobile-floating: var(--material-shadow-elevation-2dp);
 
     --navbar-z-index: 3;
-    --navbar-popup-backdrop-index: 900;
-    --navbar-popup-index: 901;
+    --navbar-popup-backdrop-z-index: 900;
+    --navbar-popup-z-index: 901;
   }
 `;
 
-const NAVBAR_STYLES = css`
+const NAVBAR_CONTAINER_STYLES = css`
   .navbar {
-    background: var(--navbar-background-color);
-    border-radius: 0px;
-    box-shadow: var(--navbar-box-shadow);
     display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-    padding: 12px;
-    gap: 10px;
+    flex-direction: column;
     width: 100vw;
     position: fixed;
+    gap: 10px;
     left: 0;
     right: 0;
     bottom: 0;
     top: unset;
     z-index: var(--navbar-z-index);
+
+    ha-card {
+      background: var(--navbar-background-color);
+      border-radius: 0px;
+      box-shadow: var(--navbar-box-shadow);
+      margin: 0 auto;
+      display: flex;
+      flex-direction: row;
+      align-items: center;
+      padding: 12px;
+      gap: 10px;
+    }
+
+    .navbar-card {
+      justify-content: space-between;
+      width: 100%;
+    }
   }
 
   /* Edit mode styles */
   .navbar.edit-mode {
     position: relative !important;
-    flex-direction: row !important;
+    flex-direction: column !important;
     left: unset !important;
     right: unset !important;
     bottom: unset !important;
-    top: unset !important;
     width: auto !important;
+    top: unset !important;
     transform: none !important;
+
+    ha-card {
+      width: 100% !important;
+      flex-direction: row !important;
+    }
   }
 
-  /* Mobile mode styles */
+  /* Mobile floating style */
   .navbar.mobile.floating {
-    border-radius: var(--navbar-border-radius) !important;
-    border: none !important;
-    box-shadow: var(--navbar-box-shadow-mobile) !important;
+    .navbar-card {
+      border: none !important;
+      box-shadow: var(--navbar-box-shadow-mobile-floating) !important;
+      border-radius: var(--navbar-border-radius) !important;
+    }
   }
   .navbar.mobile.floating:not(.edit-mode) {
-    bottom: 10px !important;
-    left: 5vw !important;
-    right: 5vw !important;
-    width: 90vw !important;
+    .navbar-card {
+      margin-bottom: 10px !important;
+      width: 90% !important;
+    }
   }
 
   /* Desktop mode styles */
   .navbar.desktop {
-    border-radius: var(--navbar-border-radius);
-    box-shadow: var(--navbar-box-shadow-desktop);
     width: auto;
     justify-content: space-evenly;
 
     --navbar-route-icon-size: 28px;
+
+    ha-card {
+      border-radius: var(--navbar-border-radius);
+      box-shadow: var(--navbar-box-shadow-desktop);
+    }
   }
   .navbar.desktop.bottom {
-    flex-direction: row;
+    flex-direction: column;
     top: unset;
     right: unset;
     bottom: 16px;
     left: calc(50% + var(--mdc-drawer-width, 0px) / 2);
     transform: translate(-50%, 0);
+
+    .navbar-card {
+      flex-direction: row;
+    }
   }
   .navbar.desktop.top {
-    flex-direction: row;
+    flex-direction: column;
     bottom: unset;
     right: unset;
     top: 16px;
     left: calc(50% + var(--mdc-drawer-width, 0px) / 2);
     transform: translate(-50%, 0);
+
+    .navbar-card {
+      flex-direction: row;
+    }
   }
   .navbar.desktop.left {
-    flex-direction: column;
+    flex-direction: row-reverse;
     left: calc(var(--mdc-drawer-width, 0px) + 16px);
     right: unset;
     bottom: unset;
     top: 50%;
     transform: translate(0, -50%);
+
+    .navbar-card {
+      flex-direction: column;
+    }
   }
   .navbar.desktop.right {
-    flex-direction: column;
+    flex-direction: row;
     right: 16px;
     left: unset;
     bottom: unset;
     top: 50%;
     transform: translate(0, -50%);
+
+    .navbar-card {
+      flex-direction: column;
+    }
+  }
+`;
+
+const MEDIA_PLAYER_STYLES = css`
+  .navbar {
+    .media-player.error {
+      padding: 0px !important;
+      ha-alert {
+        width: 100%;
+      }
+    }
+
+    .media-player {
+      cursor: pointer;
+      width: 90%;
+      overflow: hidden;
+      position: relative;
+      border: none;
+      box-shadow: var(--navbar-box-shadow-mobile-floating);
+      border-radius: var(--navbar-border-radius);
+      display: flex;
+      flex-direction: row;
+
+      .media-player-bg {
+        position: absolute;
+        inset: 0;
+        background-size: cover;
+        background-position: center;
+        filter: blur(20px);
+        opacity: 0.03;
+        z-index: 0;
+      }
+
+      .media-player-image {
+        width: 48px;
+        height: 48px;
+        border-radius: 14px;
+        object-fit: cover;
+        margin-right: 6px;
+      }
+
+      .media-player-info {
+        display: flex;
+        flex-direction: column;
+        flex: 1;
+      }
+
+      .media-player-title {
+        font-size: 14px;
+        font-weight: 500;
+      }
+
+      .media-player-artist {
+        font-size: 12px;
+        color: var(--secondary-text-color);
+      }
+
+      .media-player-button {
+        width: 38px;
+        --ha-button-height: 38px;
+        --ha-button-border-radius: 999px;
+      }
+
+      .media-player-button.media-player-button-play-pause {
+      }
+
+      .media-player-progress-bar {
+        position: absolute;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        height: 4px;
+      }
+
+      .media-player-progress-bar-fill {
+        background-color: var(--navbar-primary-color);
+        height: 100%;
+      }
+    }
   }
 `;
 
@@ -209,7 +325,7 @@ const POPUP_STYLES = css`
     top: 0;
     left: 0;
     opacity: 0;
-    z-index: var(--navbar-popup-backdrop-index);
+    z-index: var(--navbar-popup-backdrop-z-index);
     transition: opacity 0.2s ease;
   }
 
@@ -226,7 +342,7 @@ const POPUP_STYLES = css`
     opacity: 0;
     padding: 6px;
     gap: 10px;
-    z-index: var(--navbar-popup-index);
+    z-index: var(--navbar-popup-z-index);
 
     display: flex;
     justify-content: center;
@@ -351,7 +467,8 @@ export const getDefaultStyles = (): CSSResult => {
   // Mobile-first css styling
   return css`
     ${HOST_STYLES}
-    ${NAVBAR_STYLES}
+    ${NAVBAR_CONTAINER_STYLES}
+    ${MEDIA_PLAYER_STYLES}
     ${ROUTE_STYLES}
     ${POPUP_STYLES}
   `;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,12 @@
 import { HomeAssistant } from 'custom-card-helpers';
 
+// Extend the `HomeAssistant` type to include updated properties.
+declare module 'custom-card-helpers' {
+  interface HomeAssistant {
+    entities: Record<string, { icon?: string; [key: string]: unknown }>;
+  }
+}
+
 export type NavbarCardPublicState = {
   isDesktop: boolean;
 };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -64,7 +64,7 @@ const extractAccessibleStateVariables = (
   navbar: NavbarCard,
 ): NavbarCardPublicState => {
   return {
-    isDesktop: navbar._isDesktop ?? false,
+    isDesktop: navbar.isDesktop ?? false,
   };
 };
 


### PR DESCRIPTION
> [!CAUTION]
> **Breaking change!**
> This release introduces breaking changes for users who have customized css styles. More info in the `CSS styles` section.

## New `media_player` widget

This release brings in a huge new feature. A new `media_player` widget that displays on top of navbar-card when the configured media_player is playing.

<img width="451" height="843" alt="release_media-player" src="https://github.com/user-attachments/assets/09b79ae5-23e0-47ec-9856-6e3c774671d3" />

To enable it, simply add your entity under the new `media_player` config:

```yaml
type: custom:navbar-card
media_player:
  entity: media_player.your_entity_id
...
```

## CSS styles

To be able to properly implement the media player widget, some internal refactor was needed for `navbar-card`. Said refactor means some CSS class names have been renamed or moved:
- `.navbar` is now the main container of the card. Being just a div containing both the `.navbar-card` and the `.media-player` widget. This class controls the positioning of `navbar-card` in the screen.
- `.navbar-card` is now the `ha-card` itself, which contains all CSS styles for the card
- `.media-player` is a the new `ha-card` with the media player widget

Users who have custom styles to just change **positioning related styles**, need to make no changes to their styles prop:

```yaml
type: custom:navbar-card
...
styles: |
  .navbar.desktop.bottom {
    bottom: 100px;
  }
```

On the other hand, users who have visual customizations like border-radius, background, colors... etc, will need to now reference `.navbar-card`:

```yaml
type: custom:navbar-card
...
styles: |
  .navbar-card.desktop.bottom {
    background: green;
    border-radius: 300px;
  }
```