### PR TITLE
fix: popup items spacing

### DIFF
--- a/src/styles.ts
+++ b/src/styles.ts
@@ -367,9 +367,17 @@ const POPUP_STYLES = css`
     margin-left: 32px;
   }
 
+  .navbar-popup.open-right.popuplabelbackground {
+    gap: 24px;
+  }
+
   .navbar-popup.open-left {
     flex-direction: row-reverse;
     margin-right: 32px;
+  }
+
+  .navbar-popup.open-left.popuplabelbackground {
+    gap: 24px;
   }
 
   .navbar-popup.label-right {
@@ -383,7 +391,7 @@ const POPUP_STYLES = css`
   .navbar-popup.visible {
     opacity: 1;
   }
-  
+
   .navbar-popup.popuplabelbackground {
     padding-left: 0px;
   }


### PR DESCRIPTION
When using navbar-card in vertical, and `use_popup_label_backgrounds` is set to true, the popup items were really close together. (fixes #148 )

<img width="313" height="106" alt="Screenshot 2025-08-25 at 10 18 38" src="https://github.com/user-attachments/assets/12086834-7b8a-4de5-97b1-44e9cfe26a51" />
<img width="320" height="109" alt="Screenshot 2025-08-25 at 10 19 03" src="https://github.com/user-attachments/assets/24267674-52aa-4e4e-b7b6-71e6132fef12" />

