### PR TITLE
Fix/media player default icon

### DIFF
--- a/src/components/media-player.ts
+++ b/src/components/media-player.ts
@@ -1,6 +1,6 @@
 import { html } from 'lit';
 import { NavbarCard } from '@/navbar-card';
-import { fireDOMEvent, processTemplate } from '@/utils';
+import { fireDOMEvent, preventEventDefault, processTemplate } from '@/utils';
 import { ActionEvents, ActionableElement } from '@/components/action-events';
 import { ExtendedActionConfig } from '@/types';
 
@@ -185,7 +185,9 @@ export class MediaPlayer implements ActionableElement {
           class="media-player-button media-player-button-play-pause"
           appearance="accent"
           variant="brand"
-          @click=${this._handleMediaPlayerPlayPauseClick}>
+          @click=${this._handleMediaPlayerPlayPauseClick}
+          @pointerdown=${preventEventDefault}
+          @pointerup=${preventEventDefault}>
           <ha-icon
             icon=${mediaPlayerState.state === 'playing'
               ? 'mdi:pause'
@@ -195,7 +197,9 @@ export class MediaPlayer implements ActionableElement {
           class="media-player-button media-player-button-skip"
           appearance="plain"
           variant="neutral"
-          @click=${this._handleMediaPlayerSkipNextClick}>
+          @click=${this._handleMediaPlayerSkipNextClick}
+          @pointerdown=${preventEventDefault}
+          @pointerup=${preventEventDefault}>
           <ha-icon icon="mdi:skip-next"></ha-icon>
         </ha-button>
       </ha-card>

--- a/src/components/media-player.ts
+++ b/src/components/media-player.ts
@@ -133,6 +133,7 @@ export class MediaPlayer implements ActionableElement {
     }
 
     const mediaPlayerState = this._navbarCard._hass.states[entity];
+    const mediaPlayerImage = mediaPlayerState.attributes.entity_picture;
     const progress =
       mediaPlayerState.attributes.media_position != null
         ? mediaPlayerState.attributes.media_position /
@@ -164,10 +165,14 @@ export class MediaPlayer implements ActionableElement {
                 style="width: ${progress * 100}%"></div>
             </div>`
           : html``}
-        <img
-          class="media-player-image"
-          src=${mediaPlayerState.attributes.entity_picture}
-          alt=${mediaPlayerState.attributes.media_title} />
+        ${mediaPlayerImage
+          ? html`<img
+              class="media-player-image"
+              src=${mediaPlayerImage}
+              alt=${mediaPlayerState.attributes.media_title} />`
+          : html`<ha-icon
+              class="media-player-image media-player-icon-fallback"
+              icon="mdi:music"></ha-icon>`}
         <div class="media-player-info">
           <span class="media-player-title"
             >${mediaPlayerState.attributes.media_title}</span

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -182,6 +182,13 @@ const MEDIA_PLAYER_STYLES = css`
     margin-right: 6px;
   }
 
+  .media-player .media-player-icon-fallback {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background-color: var(--disabled-color);
+  }
+
   .media-player .media-player-info {
     display: flex;
     flex-direction: column;

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -283,3 +283,13 @@ export const injectStyles = (
 export const hapticFeedback = (hapticType: string = 'selection') => {
   return fireDOMEvent(window, 'haptic', undefined, hapticType);
 };
+
+/**
+ * Prevent the default action of an event and stop the propagation of the event.
+ *
+ * @param e - The event to prevent the default action of.
+ */
+export const preventEventDefault = (e: Event) => {
+  e.preventDefault();
+  e.stopPropagation();
+};


### PR DESCRIPTION
- When the current media player does not have `entity_picture` attribute, display a placeholder icon in the media player widget.
- Fixed bug where clicking on a media player button, would propagate the event to the media player widget itself.