### PR TITLE
fix: popup item label cropped when using `show_popup_label_backgrounds`

### DIFF
--- a/src/components/navbar/route/popup/popup-item.ts
+++ b/src/components/navbar/route/popup/popup-item.ts
@@ -28,6 +28,7 @@ export class PopupItem extends BaseRoute {
         popup-item
         ${popupDirectionClassName}
         ${labelPositionClassName}
+        ${showLabelBackground ? 'popuplabelbackground' : ''}
         ${this.selected ? 'active' : ''}
       "
       style="--index: ${this._index}"

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -494,6 +494,10 @@ const POPUP_STYLES = css`
     --icon-primary-color: var(--navbar-primary-color);
   }
 
+  .popup-item.popuplabelbackground {
+    max-width: unset;
+  }
+
   .popup-item.active .button {
     color: var(--navbar-primary-color);
     background: color-mix(in srgb, var(--navbar-primary-color) 30%, white);


### PR DESCRIPTION
- Fixed issue where labels appeared cropped when using `show_popup_label_backgrounds` option (closes #190)