### PR TITLE
Release/1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/styles.ts
+++ b/src/styles.ts
@@ -11,7 +11,7 @@ const HOST_STYLES = css`
     --navbar-box-shadow-desktop: var(--material-shadow-elevation-2dp);
     --navbar-box-shadow-mobile-floating: var(--material-shadow-elevation-2dp);
 
-    --navbar-z-index: 7;
+    --navbar-z-index: 3;
     --navbar-popup-backdrop-z-index: 900;
     --navbar-popup-z-index: 901;
   }


### PR DESCRIPTION
- Revert z-index of navbar-card back to 3, to prevent collision with other cards such as bubble-card. (closes #201 )