### PR TITLE
Fix Show Popup Label Backgrounds only setting desktop setting

### DIFF
--- a/src/navbar-card-editor.ts
+++ b/src/navbar-card-editor.ts
@@ -1077,10 +1077,10 @@ export class NavbarCardEditor extends LitElement {
           })}
           ${this.makeSwitch({
             label: 'Show popup label backgrounds',
-            configKey: 'desktop.show_popup_label_backgrounds',
+            configKey: 'mobile.show_popup_label_backgrounds',
             disabled: ![true, 'popup_only'].includes(labelVisibility),
             defaultValue:
-              DEFAULT_NAVBAR_CONFIG.desktop?.show_popup_label_backgrounds,
+              DEFAULT_NAVBAR_CONFIG.mobile?.show_popup_label_backgrounds,
           })}
           ${this.makeTemplateEditor({
             // TODO JLAQ maybe replace with a templateSwitchEditor


### PR DESCRIPTION
Fixes a issue where checking Show Popup Label Backgrounds under mobile settings changes the desktop value. Looks like a copy-paste error.