### PR TITLE
fix: properly read default values for haptic configuration

### DIFF
--- a/src/navbar-card-editor.ts
+++ b/src/navbar-card-editor.ts
@@ -906,23 +906,26 @@ export class NavbarCardEditor extends LitElement {
           ${this.makeSwitch({
             label: 'When pressing routes with URL configured',
             configKey: 'haptic.url',
-            defaultValue: hapticValue,
+            defaultValue: hapticValue ?? DEFAULT_NAVBAR_CONFIG.haptic.url,
           })}
           ${this.makeSwitch({
             label: "When executing the 'tap_action' configured for a route",
             configKey: 'haptic.tap_action',
-            defaultValue: hapticValue,
+            defaultValue:
+              hapticValue ?? DEFAULT_NAVBAR_CONFIG.haptic.tap_action,
           })}
           ${this.makeSwitch({
             label: "When executing the 'hold_action' configured for a route",
             configKey: 'haptic.hold_action',
-            defaultValue: hapticValue,
+            defaultValue:
+              hapticValue ?? DEFAULT_NAVBAR_CONFIG.haptic.hold_action,
           })}
           ${this.makeSwitch({
             label:
               "When executing the 'double_tap_action' configured for a route",
             configKey: 'haptic.double_tap_action',
-            defaultValue: hapticValue,
+            defaultValue:
+              hapticValue ?? DEFAULT_NAVBAR_CONFIG.haptic.double_tap_action,
           })}
         </div>
       </ha-expansion-panel>

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -176,6 +176,12 @@ export const DEFAULT_NAVBAR_CONFIG = {
     show_popup_label_backgrounds: false,
     mode: 'docked',
   },
+  haptic: {
+    url: false,
+    tap_action: false,
+    hold_action: true,
+    double_tap_action: true,
+  },
 } as const satisfies NavbarCardConfig;
 
 export const STUB_CONFIG: NavbarCardConfig = {

--- a/src/utils/haptic.ts
+++ b/src/utils/haptic.ts
@@ -1,4 +1,5 @@
 import { NavbarCard } from '@/navbar-card';
+import { DEFAULT_NAVBAR_CONFIG } from '@/types';
 import { fireDOMEvent } from '@/utils';
 
 const shouldTriggerHaptic = (
@@ -6,31 +7,31 @@ const shouldTriggerHaptic = (
   actionType: 'tap' | 'hold' | 'double_tap',
   isNavigation = false,
 ): boolean => {
-  const hapticConfig = context.config?.haptic;
+  const hapticConfig = context.config?.haptic ?? DEFAULT_NAVBAR_CONFIG.haptic;
 
   // If haptic is a boolean, use it as a global setting
   if (typeof hapticConfig === 'boolean') {
     return hapticConfig;
   }
 
-  // If no haptic config is provided, return default values
-  if (!hapticConfig) {
-    return !isNavigation;
-  }
-
   // Check navigation first
   if (isNavigation) {
-    return hapticConfig.url ?? false;
+    return hapticConfig.url ?? DEFAULT_NAVBAR_CONFIG.haptic.url;
   }
 
   // Check specific action types
   switch (actionType) {
     case 'tap':
-      return hapticConfig.tap_action ?? false;
+      return hapticConfig.tap_action ?? DEFAULT_NAVBAR_CONFIG.haptic.tap_action;
     case 'hold':
-      return hapticConfig.hold_action ?? false;
+      return (
+        hapticConfig.hold_action ?? DEFAULT_NAVBAR_CONFIG.haptic.hold_action
+      );
     case 'double_tap':
-      return hapticConfig.double_tap_action ?? false;
+      return (
+        hapticConfig.double_tap_action ??
+        DEFAULT_NAVBAR_CONFIG.haptic.double_tap_action
+      );
     default:
       return false;
   }


### PR DESCRIPTION
- Fix default `haptic` values not being properly displayed on the visual editor. (closes #239)