### PR TITLE
Feature/292 popup menu speed

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "navbar-card",
-  "version": "1.6.0",
+  "version": "1.5.0",
   "author": "Jose Álvarez Quiroga <joseluisalvquiroga@gmail.com>",
   "repository": "git@github.com:joseluis9595/lovelace-navbar-card.git",
   "license": "MIT",

--- a/src/components/navbar/route/popup/popup.ts
+++ b/src/components/navbar/route/popup/popup.ts
@@ -43,6 +43,10 @@ export class Popup {
               DesktopPosition.bottom),
       );
 
+    const popupStaggerStep = this._getPopupStaggerStepSeconds(
+      this.items.length,
+    );
+
     this._navbarCard.focusedPopup = html`
       <div class="navbar-popup-backdrop"></div>
       <div
@@ -54,7 +58,7 @@ export class Popup {
           mobile: !this._navbarCard.isDesktop,
           popuplabelbackground: this._shouldShowLabelBackground(),
         })}
-        style="${style}">
+        style="${style}; --popup-item-stagger-step: ${popupStaggerStep}s;">
         ${this.items
           .map(popupItem =>
             popupItem.render(popupDirectionClassName, labelPositionClassName),
@@ -124,6 +128,16 @@ export class Popup {
       : this._navbarCard.config?.mobile?.show_popup_label_backgrounds;
     return !!enabled;
   };
+
+  private _getPopupStaggerStepSeconds(itemsCount: number): number {
+    const maxTotalStaggerDelaySeconds = 0.25;
+    const minStepSeconds = 0.01;
+    const maxStepSeconds = 0.05;
+    const staggeredTransitions = Math.max(itemsCount - 1, 1);
+    const dynamicStep = maxTotalStaggerDelaySeconds / staggeredTransitions;
+
+    return Math.max(minStepSeconds, Math.min(maxStepSeconds, dynamicStep));
+  }
 
   /**
    * Get the styles for the popup based on its position relative to the anchor element.

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -615,7 +615,7 @@ const POPUP_STYLES = css`
   .navbar-popup.visible .popup-item {
     opacity: 1;
     transform: translateY(0);
-    transition-delay: calc(var(--index) * 0.05s);
+    transition-delay: calc(var(--index) * var(--popup-item-stagger-step, 0.05s));
   }
 
   .popup-item.label-bottom {


### PR DESCRIPTION
- When opening popups, increase animation speed based on number of popup items. That means, the larger the amount of items, the faster the animation per-item will be (closes #292 )