### PR TITLE
fix: open quickbar via HA's own entry point (broken on HA 2026.6+)

### DIFF
--- a/src/__tests__/lib/action-handler.test.ts
+++ b/src/__tests__/lib/action-handler.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { NavbarCard } from '@/navbar-card';
+import { NavbarCustomActions } from '@/types';
+
+import { executeAction } from '../../lib/action-handler';
+
+// Minimal NavbarCard stand-in: for the quickbar action, executeAction only reads
+// `context.config` (through the haptic helper).
+const createContext = () => ({ config: {} }) as unknown as NavbarCard;
+
+const runQuickbar = (mode?: 'entities' | 'devices' | 'commands') => {
+  executeAction({
+    action: mode
+      ? { action: NavbarCustomActions.quickbar, mode }
+      : { action: NavbarCustomActions.quickbar },
+    actionType: 'tap',
+    context: createContext(),
+    data: {},
+    target: document.createElement('div'),
+  });
+};
+
+describe('quickbar action', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    document.querySelector('home-assistant')?.remove();
+  });
+
+  it('calls the HA quickbar entry point with the mapped mode (HA 2026.6+)', () => {
+    const showQuickBar = vi.fn();
+    const haRoot = document.createElement('home-assistant') as HTMLElement & {
+      _showQuickBar?: unknown;
+    };
+    haRoot._showQuickBar = showQuickBar;
+    document.body.appendChild(haRoot);
+
+    runQuickbar('entities');
+
+    expect(showQuickBar).toHaveBeenCalledTimes(1);
+    const [event, mode] = showQuickBar.mock.calls[0];
+    expect(mode).toBe('entity');
+    // The synthetic event must satisfy HA's `_canShowQuickBar` guard, which reads
+    // `composedPath()[0].tagName` and `defaultPrevented`.
+    expect(event.composedPath()).toContain(document.body);
+    expect(event.defaultPrevented).toBe(false);
+    expect(typeof event.preventDefault).toBe('function');
+  });
+
+  it('maps every configured mode to its HA quickbar section', () => {
+    const showQuickBar = vi.fn();
+    const haRoot = document.createElement('home-assistant') as HTMLElement & {
+      _showQuickBar?: unknown;
+    };
+    haRoot._showQuickBar = showQuickBar;
+    document.body.appendChild(haRoot);
+
+    runQuickbar('devices');
+    runQuickbar('commands');
+    runQuickbar(); // no mode -> default quickbar
+
+    expect(showQuickBar.mock.calls.map(call => call[1])).toEqual([
+      'device',
+      'command',
+      undefined,
+    ]);
+  });
+
+  it('falls back to a synthetic keyboard shortcut when the entry point is absent (older HA)', () => {
+    const dispatchSpy = vi.spyOn(document, 'dispatchEvent');
+
+    runQuickbar('entities');
+
+    expect(dispatchSpy).toHaveBeenCalledTimes(1);
+    const event = dispatchSpy.mock.calls[0][0] as KeyboardEvent;
+    expect(event.type).toBe('keydown');
+    expect(event.key).toBe('e');
+  });
+});

--- a/src/lib/action-handler.ts
+++ b/src/lib/action-handler.ts
@@ -23,10 +23,23 @@ import {
 export const ACTIONS_WITH_CUSTOM_ENTITY = ['more-info', 'toggle'];
 
 /**
+ * Maps navbar-card's `mode` config onto Home Assistant's quickbar section names.
+ */
+const QUICKBAR_MODES = {
+  commands: 'command',
+  devices: 'device',
+  entities: 'entity',
+} as const;
+
+/**
  * Opens Home Assistant's quickbar by simulating the keyboard shortcut.
  * Uses Ctrl/Cmd + K for the standard quickbar, or mode-specific keys if specified.
+ *
+ * This is a fallback for HA < 2026.6. Newer frontends no longer observe synthetic
+ * `keydown` events dispatched at `document` (see `openQuickbar`), so this path only
+ * runs when the modern entry point below is unavailable.
  */
-const openQuickbar = (action: QuickbarActionConfig) => {
+const openQuickbarViaKeyboard = (action: QuickbarActionConfig) => {
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   let key: string;
 
@@ -66,6 +79,46 @@ const openQuickbar = (action: QuickbarActionConfig) => {
   const event = new KeyboardEvent('keydown', eventInit);
 
   document.dispatchEvent(event);
+};
+
+/**
+ * Opens Home Assistant's quickbar.
+ *
+ * HA 2026.6 reworked keyboard-shortcut capture (a tinykeys-based `ShortcutManager`)
+ * and no longer reacts to synthesized `keydown` events dispatched at `document`, so
+ * the previous "simulate the shortcut" approach silently stopped working
+ * (https://github.com/joseluis9595/lovelace-navbar-card/issues/312).
+ *
+ * We instead call the frontend's own quickbar entry point (`_showQuickBar`) on the
+ * `<home-assistant>` root. That fires the same `show-dialog` event the shortcut
+ * handlers use and — importantly — loads the `ha-quick-bar` dialog through HA's own
+ * importer, so it also works on a cold session. When that entry point is missing
+ * (older HA), we fall back to the legacy synthetic-key dispatch.
+ */
+const openQuickbar = (action: QuickbarActionConfig) => {
+  const haRoot = document.querySelector('home-assistant') as
+    | (HTMLElement & {
+        _showQuickBar?: (e: Event, mode?: string) => void;
+      })
+    | null;
+
+  if (haRoot && typeof haRoot._showQuickBar === 'function') {
+    // `_showQuickBar(e, mode)` runs `_canShowQuickBar(e)`, which reads
+    // `e.composedPath()[0].tagName`, then checks `e.defaultPrevented` and calls
+    // `e.preventDefault()`. Provide a minimal event that satisfies those checks,
+    // with a `composedPath` that resolves to a non-input element so the "don't
+    // hijack typing" guard passes.
+    const syntheticEvent = {
+      composedPath: () => [document.body],
+      defaultPrevented: false,
+      preventDefault: () => undefined,
+    } as unknown as Event;
+    const mode = action.mode ? QUICKBAR_MODES[action.mode] : undefined;
+    haRoot._showQuickBar(syntheticEvent, mode);
+    return;
+  }
+
+  openQuickbarViaKeyboard(action);
 };
 
 /**


### PR DESCRIPTION
## What & why

The `quickbar` action stopped opening the search dialog on **Home Assistant 2026.6+** (#312).

navbar-card opened the quickbar by building a synthetic `KeyboardEvent('keydown', …)` and dispatching it at `document`, relying on HA's global keyboard-shortcut handler to catch it. HA 2026.6 reworked shortcut capture into a tinykeys-based `ShortcutManager` (`src/state/quick-bar-mixin.ts`) that **no longer observes synthesized events dispatched at `document`** — so the action silently did nothing, with no console error. (There's a second gate too: `_canShowQuickBar` reads `e.composedPath()[0].tagName`, and a synthesized event's `composedPath()` is empty.)

## The fix

Call the frontend's own quickbar entry point — `_showQuickBar(e, mode)` on the `<home-assistant>` root — instead of faking a keypress. That's the exact method the shortcut handlers invoke; it fires the same `show-dialog` event **and loads the `ha-quick-bar` dialog through HA's own importer**, so it also works on a cold session (a plain `show-dialog` with `dialogImport: () => Promise.resolve()` does not — the dialog never loads the first time).

- The configured `mode` maps onto HA's quickbar sections: `entities → entity`, `devices → device`, `commands → command`; no mode → default bar.
- A minimal synthetic event satisfies `_canShowQuickBar` (`composedPath()` resolves to `document.body`, `defaultPrevented` is `false`, `preventDefault` is callable).
- When `_showQuickBar` isn't present (**HA < 2026.6**), it falls back to the original synthetic-key dispatch, so older installs are unaffected.

## How to test

1. On HA 2026.6+, add a route with `tap_action: { action: quickbar, mode: entities }`.
2. Tap it → the quickbar opens in Entities mode. Also verify `devices`, `commands`, and no-mode.

I verified the underlying mechanism live on **HA 2026.7.2 / navbar-card 1.6.1** (calling `_showQuickBar` opens the dialog on a cold page load, including with `mode: entities`). New unit tests in `src/__tests__/lib/action-handler.test.ts` cover the mode mapping, the synthetic-event guard, and the legacy fallback. `bun run build` and the full `bun test` suite (193 tests) pass.

## Notes

- Like HA's own keyboard shortcuts, `_showQuickBar` respects the per-profile **"Enable shortcuts"** setting; if a user turns that off, the button no-ops on that browser (same as pressing `e`/`ctrl+k`).
- `command` / `device` sections remain admin-only on HA's side (unchanged behavior).

Fixes #312
