### PR TITLE
feat(mobile): dock navbar to the right in landscape orientation

### DIFF
--- a/docs/docs/configuration/mobile.mdx
+++ b/docs/docs/configuration/mobile.mdx
@@ -13,12 +13,13 @@ Specific configuration for mobile mode.
   alignment="center"
 />
 
-| Name                           | Type                                          | Default  | Description                                                                                                             |
-| ------------------------------ | --------------------------------------------- | -------- | ----------------------------------------------------------------------------------------------------------------------- |
-| `mode`                         | `docked` \| `floating`                        | `docked` | Choose visualization mode on mobile devices. `docked` for default experience, `floating` for desktop-like visualization |
-| `show_labels`                  | boolean \| `popup_only` \| `routes_only`      | `false`  | Whether or not to display labels under each route                                                                       |
-| `show_popup_label_backgrounds` | boolean                                       | `false`  | Whether or not to display label backgrounds for popup items                                                             |
-| `hidden`                       | boolean \| [JSTemplate](../types/js-template) | `false`  | Set to true to hide the navbar on mobile devices                                                                        |
+| Name                           | Type                                          | Default  | Description                                                                                                                                                  |
+| ------------------------------ | --------------------------------------------- | -------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode`                         | `docked` \| `floating`                        | `docked` | Choose visualization mode on mobile devices. `docked` for default experience, `floating` for desktop-like visualization                                        |
+| `position`                     | `bottom` \| `right`                           | `bottom` | Where to dock the navbar. `right` only takes effect while the device is in **landscape** orientation - portrait always docks to the bottom regardless of this setting |
+| `show_labels`                  | boolean \| `popup_only` \| `routes_only`      | `false`  | Whether or not to display labels under each route                                                                                                               |
+| `show_popup_label_backgrounds` | boolean                                       | `false`  | Whether or not to display label backgrounds for popup items                                                                                                     |
+| `hidden`                       | boolean \| [JSTemplate](../types/js-template) | `false`  | Set to true to hide the navbar on mobile devices                                                                                                                |
 
 <br />
 

--- a/src/__tests__/navbar-card.test.ts
+++ b/src/__tests__/navbar-card.test.ts
@@ -2,7 +2,11 @@ import { fixture, html } from '@open-wc/testing';
 import type { HomeAssistant } from 'custom-card-helpers';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { NavbarCardConfig } from '@/types';
+import {
+  DesktopPosition,
+  MobilePosition,
+  type NavbarCardConfig,
+} from '@/types';
 
 import { NavbarCard } from '../navbar-card';
 
@@ -157,6 +161,54 @@ describe('NavbarCard', () => {
       await element.updateComplete;
 
       expect(element.isDesktop).toBe(false);
+    });
+  });
+
+  describe('Mobile position', () => {
+    beforeEach(async () => {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        value: 375,
+        writable: true,
+      });
+      window.dispatchEvent(new Event('resize'));
+      await element.updateComplete;
+    });
+
+    it('defaults to bottom position class', () => {
+      expect(element.mobilePosition).toBe(MobilePosition.bottom);
+
+      const navbar = element.shadowRoot?.querySelector('.navbar');
+      expect(navbar?.classList.contains('mobile')).toBe(true);
+      expect(navbar?.classList.contains('bottom')).toBe(true);
+      expect(navbar?.classList.contains('right')).toBe(false);
+    });
+
+    it('applies right position class when configured', async () => {
+      element.setConfig({
+        ...DEFAULT_CONFIG,
+        mobile: { position: MobilePosition.right },
+      });
+      await element.updateComplete;
+
+      expect(element.mobilePosition).toBe(MobilePosition.right);
+
+      const navbar = element.shadowRoot?.querySelector('.navbar');
+      const navbarCard = element.shadowRoot?.querySelector('.navbar-card');
+      expect(navbar?.classList.contains('right')).toBe(true);
+      expect(navbarCard?.classList.contains('right')).toBe(true);
+    });
+
+    it('does not leak desktop position class onto a mobile navbar', async () => {
+      element.setConfig({
+        ...DEFAULT_CONFIG,
+        desktop: { position: DesktopPosition.left },
+      });
+      await element.updateComplete;
+
+      const navbar = element.shadowRoot?.querySelector('.navbar');
+      expect(navbar?.classList.contains('left')).toBe(false);
+      expect(navbar?.classList.contains('bottom')).toBe(true);
     });
   });
 

--- a/src/__tests__/utils/dom.test.ts
+++ b/src/__tests__/utils/dom.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   DesktopPosition,
+  MobilePosition,
   type NavbarCardConfig,
   WidgetPosition,
 } from '@/types/config';
@@ -349,6 +350,68 @@ describe('DOM utilities', () => {
       expect(styleEl).toBeTruthy();
       expect(styleEl.textContent).toContain('@media (max-width: 767px)');
       expect(styleEl.textContent).toContain('height: 80px');
+    });
+
+    it('should add mobile bottom padding gated to portrait when position is right', () => {
+      const options = {
+        autoPadding: { enabled: true, mobile_px: 80 },
+        desktop: { min_width: 768 },
+        mobile: { position: MobilePosition.right },
+        widgetPositions: {
+          media_player: null,
+        },
+      };
+
+      forceDashboardPadding(options);
+
+      const styleEl = mockHuiRoot.shadowRoot?.querySelector(
+        '#navbar-card-forced-padding-styles',
+      ) as HTMLStyleElement;
+      expect(styleEl).toBeTruthy();
+      expect(styleEl.textContent).toContain(
+        '@media (max-width: 767px) and (orientation: portrait)',
+      );
+      expect(styleEl.textContent).toContain('height: 80px');
+    });
+
+    it('should add mobile right padding gated to landscape when position is right', () => {
+      const options = {
+        autoPadding: { enabled: true, mobile_px: 80 },
+        desktop: { min_width: 768 },
+        mobile: { position: MobilePosition.right },
+        widgetPositions: {
+          media_player: null,
+        },
+      };
+
+      forceDashboardPadding(options);
+
+      const styleEl = mockHuiRoot.shadowRoot?.querySelector(
+        '#navbar-card-forced-padding-styles',
+      ) as HTMLStyleElement;
+      expect(styleEl).toBeTruthy();
+      expect(styleEl.textContent).toContain(
+        '@media (max-width: 767px) and (orientation: landscape)',
+      );
+      expect(styleEl.textContent).toContain('padding-right: 80px !important');
+    });
+
+    it('should not add orientation-gated queries for the default bottom mobile position', () => {
+      const options = {
+        autoPadding: { enabled: true, mobile_px: 80 },
+        desktop: { min_width: 768 },
+        mobile: {},
+        widgetPositions: {
+          media_player: null,
+        },
+      };
+
+      forceDashboardPadding(options);
+
+      const styleEl = mockHuiRoot.shadowRoot?.querySelector(
+        '#navbar-card-forced-padding-styles',
+      ) as HTMLStyleElement;
+      expect(styleEl.textContent).not.toContain('orientation');
     });
 
     it('should add media player padding to mobile when enabled', () => {

--- a/src/components/navbar/route/popup/popup.ts
+++ b/src/components/navbar/route/popup/popup.ts
@@ -3,7 +3,11 @@ import { classMap } from 'lit/directives/class-map.js';
 
 import { PopupItem } from '@/components/navbar';
 import type { NavbarCard } from '@/navbar-card';
-import { DesktopPosition, type PopupItem as PopupItemDef } from '@/types';
+import {
+  DesktopPosition,
+  MobilePosition,
+  type PopupItem as PopupItemDef,
+} from '@/types';
 
 export class Popup {
   private _popupItems: PopupItem[] = [];
@@ -34,13 +38,23 @@ export class Popup {
   public open(target: HTMLElement): void {
     const anchorRect = target.getBoundingClientRect();
 
+    // Mobile navbars docked to the right only render that way in landscape
+    // orientation (see the CSS media query in styles/index.ts) - popups
+    // should follow the same rule and open to the left in that case.
+    const isMobileDockedRight =
+      !this._navbarCard.isDesktop &&
+      this._navbarCard.mobilePosition === MobilePosition.right &&
+      window.matchMedia('(orientation: landscape)').matches;
+
     const { style, labelPositionClassName, popupDirectionClassName } =
       this._getPopupStyles(
         anchorRect,
-        !this._navbarCard.isDesktop
-          ? 'mobile'
-          : (this._navbarCard.config?.desktop?.position ??
-              DesktopPosition.bottom),
+        this._navbarCard.isDesktop
+          ? (this._navbarCard.config?.desktop?.position ??
+              DesktopPosition.bottom)
+          : isMobileDockedRight
+            ? DesktopPosition.right
+            : 'mobile',
       );
 
     const popupStaggerStep = this._getPopupStaggerStepSeconds(

--- a/src/navbar-card-editor.ts
+++ b/src/navbar-card-editor.ts
@@ -23,6 +23,7 @@ import {
   genericSetProperty,
   type LabelVisibilityConfig,
   type MediaPlayerPlayerConfig,
+  MobilePosition,
   type NavbarCardConfig,
   NavbarCustomActions,
   type NavbarDisplayMode,
@@ -1384,6 +1385,17 @@ export class NavbarCardEditor extends LitElement {
               { label: 'Docked', value: 'docked' },
             ],
             label: 'Mode',
+          })}
+          ${this.makeComboBox<MobilePosition>({
+            configKey: 'mobile.position',
+            defaultValue: DEFAULT_NAVBAR_CONFIG.mobile?.position,
+            helper:
+              'Right only takes effect while the device is in landscape orientation. Portrait always docks to the bottom.',
+            items: [
+              { label: 'Bottom', value: MobilePosition.bottom },
+              { label: 'Right (landscape only)', value: MobilePosition.right },
+            ],
+            label: 'Position',
           })}
           ${this.makeComboBox<LabelVisibilityConfig>({
             configKey: 'mobile.show_labels',

--- a/src/navbar-card.ts
+++ b/src/navbar-card.ts
@@ -15,6 +15,7 @@ import { getDefaultStyles } from '@/styles';
 import {
   DEFAULT_NAVBAR_CONFIG,
   DesktopPosition,
+  MobilePosition,
   type NavbarCardConfig,
   STUB_CONFIG,
   WidgetPosition,
@@ -112,6 +113,20 @@ export class NavbarCard extends LitElement {
         DesktopPosition,
         this.config?.desktop?.position as string,
       ) ?? DesktopPosition.bottom
+    );
+  }
+
+  /**
+   * Where the navbar docks on mobile devices. Note that `right` only takes
+   * visual effect while the device is in landscape orientation (handled via
+   * CSS media query) - portrait always renders docked to the bottom.
+   */
+  get mobilePosition(): MobilePosition {
+    return (
+      mapStringToEnum(
+        MobilePosition,
+        this.config?.mobile?.position as string,
+      ) ?? MobilePosition.bottom
     );
   }
 
@@ -214,6 +229,9 @@ export class NavbarCard extends LitElement {
 
     const deviceClass = this.isDesktop ? 'desktop' : 'mobile';
     const editClass = this.isInEditMode ? 'edit-mode' : '';
+    const positionClass = this.isDesktop
+      ? this.desktopPosition
+      : this.mobilePosition;
     const mobileModeClass =
       this.config.mobile?.mode === 'floating' ? 'floating' : '';
     const desktopModeClass =
@@ -231,9 +249,7 @@ export class NavbarCard extends LitElement {
           : html``
       }
       <div
-        class="navbar ${editClass} ${deviceClass} ${
-          this.desktopPosition
-        } ${mobileModeClass} ${desktopModeClass}">
+        class="navbar ${editClass} ${deviceClass} ${positionClass} ${mobileModeClass} ${desktopModeClass}">
         ${
           shouldRenderMediaPlayerInsideNavbar
             ? this._mediaPlayer.render({
@@ -242,9 +258,7 @@ export class NavbarCard extends LitElement {
             : html``
         }
         <ha-card
-          class="navbar-card ${deviceClass} ${
-            this.desktopPosition
-          } ${mobileModeClass} ${desktopModeClass}">
+          class="navbar-card ${deviceClass} ${positionClass} ${mobileModeClass} ${desktopModeClass}">
           ${this._routes.map(route => route.render()).filter(Boolean)}
         </ha-card>
       </div>

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -219,6 +219,76 @@ const NAVBAR_CONTAINER_STYLES = css`
     height: 100%;
     border-radius: 0px;
   }
+
+  /*
+   * Mobile landscape right-side docking.
+   * Only takes effect in landscape orientation - in portrait the navbar
+   * always stays docked to the bottom, regardless of the "right" class.
+   */
+  @media (orientation: landscape) {
+    .navbar.mobile.right {
+      flex-direction: row;
+      width: auto;
+      height: 100%;
+      top: 0;
+      bottom: 0;
+      left: unset;
+      right: 0;
+      --navbar-route-icon-size: 28px;
+    }
+
+    .navbar-card.mobile.right {
+      flex-direction: column;
+      width: auto;
+      height: 100%;
+      border-radius: 0px;
+      justify-content: center;
+      align-items: center;
+      padding: 12px 8px;
+      gap: 10px;
+    }
+
+    /* Match desktop's fixed touch-target sizing - route/button now sit in a
+       vertical column instead of a full-width row, so the "width: 100%"
+       mobile default no longer resolves to a sane size. */
+    .mobile.right .route .label {
+      flex: unset;
+    }
+
+    .mobile.right .route {
+      height: 60px;
+      width: 70px;
+    }
+
+    .mobile.right .button {
+      flex: unset;
+      height: 100%;
+    }
+
+    .mobile.right .route:has(.label) .button {
+      height: 40px;
+    }
+
+    .navbar.mobile.right.floating {
+      height: auto;
+      top: 50%;
+      bottom: unset;
+      right: var(--navbar-edge-inset);
+      transform: translate(0, -50%);
+    }
+
+    .navbar-card.mobile.right.floating {
+      height: auto;
+      width: auto;
+      margin-bottom: 0;
+    }
+
+    .navbar.mobile.right :is(.media-player, .media-player-carousel) {
+      align-self: center;
+      width: auto;
+      max-width: calc(100vw - 100px);
+    }
+  }
 `;
 
 const MEDIA_PLAYER_STYLES = css`

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -7,6 +7,11 @@ export enum DesktopPosition {
   right = 'right',
 }
 
+export enum MobilePosition {
+  bottom = 'bottom',
+  right = 'right',
+}
+
 export enum WidgetPosition {
   topLeft = 'top-left',
   topCenter = 'top-center',
@@ -170,6 +175,12 @@ export type NavbarCardConfig = {
     show_labels?: LabelVisibilityConfig;
     show_popup_label_backgrounds?: boolean;
     hidden?: JSTemplatable<boolean>;
+    /**
+     * Where to dock the navbar on mobile devices. `right` only takes effect
+     * while the device is in landscape orientation - portrait always docks
+     * to the `bottom`, regardless of this setting.
+     */
+    position?: MobilePosition;
   };
   styles?: string;
   haptic?: boolean | HapticConfig;
@@ -204,6 +215,7 @@ export const DEFAULT_NAVBAR_CONFIG = {
   },
   mobile: {
     mode: 'docked',
+    position: MobilePosition.bottom,
     show_labels: false,
     show_popup_label_backgrounds: false,
   },

--- a/src/utils/dom.ts
+++ b/src/utils/dom.ts
@@ -4,6 +4,7 @@ import {
   type AutoPaddingConfig,
   DEFAULT_NAVBAR_CONFIG,
   DesktopPosition,
+  MobilePosition,
   type NavbarCardConfig,
   WidgetPosition,
 } from '@/types/config';
@@ -120,6 +121,7 @@ export const forceDashboardPadding = (options?: {
     },
     mobile: {
       bottom: 0,
+      right: 0,
     },
   };
 
@@ -140,6 +142,8 @@ export const forceDashboardPadding = (options?: {
   const desktopMinWidth = options?.desktop?.min_width ?? 768;
   const desktopPosition =
     options?.desktop?.position ?? DEFAULT_NAVBAR_CONFIG.desktop.position;
+  const mobilePosition =
+    options?.mobile?.position ?? DEFAULT_NAVBAR_CONFIG.mobile.position;
   const mobileMaxWidth = desktopMinWidth - 1;
   let cssText = '';
 
@@ -158,7 +162,13 @@ export const forceDashboardPadding = (options?: {
     DEFAULT_NAVBAR_CONFIG.layout?.auto_padding?.mobile_px ??
     0;
 
+  // The bottom padding always accounts for the portrait fallback layout;
+  // the right padding additionally reserves space for the landscape layout
+  // when the navbar is configured to dock to the right.
   totalPaddings.mobile.bottom += mobilePaddingPx;
+  if (mobilePosition === MobilePosition.right) {
+    totalPaddings.mobile.right += mobilePaddingPx;
+  }
 
   // Media player padding
   const mediaPlayerPaddingPx =
@@ -181,6 +191,9 @@ export const forceDashboardPadding = (options?: {
         break;
     }
     totalPaddings.mobile.bottom += mediaPlayerPaddingPx;
+    if (mobilePosition === MobilePosition.right) {
+      totalPaddings.mobile.right += mediaPlayerPaddingPx;
+    }
   }
 
   // Build CSS text
@@ -229,8 +242,14 @@ export const forceDashboardPadding = (options?: {
     `;
   }
   if (totalPaddings.mobile.bottom > 0) {
+    // When docked to the right, the bottom bar (and its padding) only
+    // applies while the device is in portrait orientation.
+    const orientationQuery =
+      mobilePosition === MobilePosition.right
+        ? ' and (orientation: portrait)'
+        : '';
     cssText += `
-        @media (max-width: ${mobileMaxWidth}px) {
+        @media (max-width: ${mobileMaxWidth}px)${orientationQuery} {
           :not(.edit-mode) > hui-view:after {
             content: "";
             display: block;
@@ -240,6 +259,18 @@ export const forceDashboardPadding = (options?: {
             }
           }
         `;
+  }
+  if (
+    mobilePosition === MobilePosition.right &&
+    totalPaddings.mobile.right > 0
+  ) {
+    cssText += `
+        @media (max-width: ${mobileMaxWidth}px) and (orientation: landscape) {
+          :not(.edit-mode) > #view {
+            padding-right: ${totalPaddings.mobile.right}px !important;
+          }
+        }
+      `;
   }
 
   // Append styles to hui-root


### PR DESCRIPTION
## What

Adds `mobile.position: 'bottom' | 'right'` (default `bottom`), mirroring the
existing `desktop.position` option. When set to `right`, the navbar docks to
the right edge of the screen **only while the device is in landscape
orientation** (via a `@media (orientation: landscape)` query) - portrait
always falls back to the existing full-width bottom bar. The change is
opt-in and non-breaking for existing configs.

Also fixes popup direction (submenus open to the left, matching
`desktop.position: right`, instead of "open up") and dashboard auto-padding
(reserves right-edge padding in landscape instead of/alongside bottom
padding) so both behave consistently with the new layout.

## Why

On phones/tablets used in landscape (e.g. wall-mounted kiosks, tablets in a
dock), a full-width bar pinned to the bottom eats into vertical space that's
already scarce in landscape. Desktop already supports docking to any edge;
this brings the same option to mobile, gated specifically to landscape so
portrait behavior is unaffected.

## How to test

```yaml
type: custom:navbar-card
mobile:
  position: right
  # mode: floating   # optional, for the desktop-style floating pill look
routes:
  - icon: mdi:home
    url: /lovelace/home
  # ...
```

- Resize a browser window under the mobile breakpoint (`desktop.min_width`,
  default 768px) and rotate the emulated device / resize taller than wide vs
  wider than tall to see the bar move between bottom (portrait) and right
  (landscape).
- Open a route's popup submenu while docked right in landscape - it should
  open to the left instead of upward.
- Confirm portrait behavior is unchanged from `main` when `position` is
  left at the default (`bottom`).

## Notes

- This PR (implementation, tests, and docs) was produced with AI assistance
  (Claude Code), reviewed and tested locally against Home Assistant before
  opening.
- 205 existing tests pass, plus new coverage in `navbar-card.test.ts` and
  `dom.test.ts` for the position getter/class rendering and the
  orientation-gated auto-padding CSS.
- `bun run build` and `bun run lint` are clean.
